### PR TITLE
Replace Gist-it with polymer-code-highlighter

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/styles/commons-demo/shared-styles.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/commons-demo/shared-styles.css
@@ -20,3 +20,12 @@
 vaadin-checkbox.smallcheckbox {
 	font-size: small;
 }
+
+code-highlighter pre.vrPre {
+	background: unset;
+	overflow-x: unset;
+}
+
+code-highlighter code {
+	background: unset;
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
@@ -29,7 +29,7 @@ public class Demo extends TabbedDemo {
 
   public Demo() {
     final String sourceCodeUrl =
-        "https://github.com/FlowingCode/CommonsDemo/blob/master/src/test/java/com/flowingcode/vaadin/addons/demo/impl/Demo.java";
+        "https://github.com/FlowingCode/CommonsDemo/blob/master/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java";
     VerticalLayout vl = new VerticalLayout();
     VerticalLayout vl2 = new VerticalLayout();
     VerticalLayout vl3 = new VerticalLayout();

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemo.java
@@ -25,10 +25,11 @@ import com.vaadin.flow.router.PageTitle;
 
 @PageTitle("Demo 4")
 @DemoSource(
-    "https://github.com/FlowingCode/CommonsDemo/blob/master/src/test/java/com/flowingcode/vaadin/addons/demo/impl/SampleDemo.java")
+"https://github.com/FlowingCode/CommonsDemo/blob/master/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemo.java")
 public class SampleDemo extends Div {
 
   public SampleDemo() {
     add(new Span("Demo component with annotations"));
   }
+
 }


### PR DESCRIPTION
This change is Backwards Compatible™ (the change in Demo.java and DemoSource.java is unrelated to the replacement of gist-it, those URL were wrong already). The chosen parser is not perfect, but it fits the bill.

![image](https://user-images.githubusercontent.com/11554739/130484373-2805fa4a-eb4a-4ebb-a282-b1dc811ddd00.png)


