### PR TITLE
feat: allow `@DemoSource` URL to default to the location of the class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.flowingcode.vaadin.addons.demo</groupId>
   <artifactId>commons-demo</artifactId>
-  <version>3.2.1-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   
   <name>Commons Demo</name>
     

--- a/src/main/java/com/flowingcode/vaadin/addons/GithubLink.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/GithubLink.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used for configuring the URL in the {@code GitHubCorner}
+ * This annotation is used for configuring the URL in the {@code GitHubCorner} and {@code DemoClass}
  *
  * @author Javier Godoy / Flowing Code
  */

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
@@ -25,7 +25,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used for configuring the source code URL in a {@link TabbedDemo}
+ * This annotation is used for configuring the source code URL in a {@link TabbedDemo}. If no
+ * {@code value} is specified, and the demo view is annotated with {@link @GithubLink}, the source
+ * URL defaults to the location of the annotated class under {@code src/java/test} in the master
+ * branch of the repository.
  *
  * @author Javier Godoy / Flowing Code
  */
@@ -33,5 +36,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DemoSource {
 
-  String value();
+  static final String GITHUB_SOURCE = "__GITHUB__";
+
+  /** A link to the source code, if different from the annotated class. */
+  String value() default GITHUB_SOURCE;
+
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -19,6 +19,7 @@
  */
 package com.flowingcode.vaadin.addons.demo;
 
+import com.flowingcode.vaadin.addons.GithubLink;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.dependency.StyleSheet;
@@ -94,10 +95,19 @@ public class TabbedDemo extends VerticalLayout {
    * @param demo the demo instance
    */
   public void addDemo(Component demo) {
-    String sourceCodeUrl =
-        Optional.ofNullable(demo.getClass().getAnnotation(DemoSource.class))
-            .map(DemoSource::value)
+    DemoSource demoSource = demo.getClass().getAnnotation(DemoSource.class);
+
+    String sourceCodeUrl = null;
+    if (demoSource != null) {
+      sourceCodeUrl = demoSource.value();
+      if (sourceCodeUrl.equals(DemoSource.GITHUB_SOURCE)) {
+        sourceCodeUrl = Optional.ofNullable(this.getClass().getAnnotation(GithubLink.class))
+            .map(githubLink -> githubLink.value() + "/blob/master/src/test/java/"
+                + demo.getClass().getName().replace('.', '/'))
             .orElse(null);
+      }
+    }
+
     String label =
         Optional.ofNullable(demo.getClass().getAnnotation(PageTitle.class))
             .map(PageTitle::value)

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
@@ -19,12 +19,14 @@
  */
 package com.flowingcode.vaadin.addons.demo;
 
+import com.flowingcode.vaadin.addons.GithubLink;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 
 /** Hello world! */
 @Route("")
+@GithubLink("https://github.com/FlowingCode/CommonsDemo")
 public class Demo extends TabbedDemo {
 
   public Demo() {
@@ -47,5 +49,6 @@ public class Demo extends TabbedDemo {
     addDemo(vl3, "Demo Without Source Code");
 
     addDemo(new SampleDemo());
+    addDemo(new SampleDemoDefault());
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
@@ -23,12 +23,12 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.PageTitle;
 
-@PageTitle("Demo 4")
-@DemoSource("https://github.com/FlowingCode/CommonsDemo/blob/master/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemo.java")
-public class SampleDemo extends Div {
+@PageTitle("Demo 5")
+@DemoSource
+public class SampleDemoDefault extends Div {
 
-  public SampleDemo() {
-    add(new Span("Demo component with annotations"));
+  public SampleDemoDefault() {
+    add(new Span("Demo component with defaulted @DemoSource annotation"));
   }
 
 }


### PR DESCRIPTION
If no `value` is specified, and the demo view is annotated with `@GithubLink`, the source URL defaults to the location of the annotated class under `src/java/test` in the master branch of the repository.