### PR TITLE
fix: remove unused import of @vaadin/vaadin-tabs

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/code-viewer.ts
+++ b/src/main/resources/META-INF/resources/frontend/code-viewer.ts
@@ -1,4 +1,3 @@
-import "@vaadin/vaadin-tabs";
 import {
   customElement,
   html,


### PR DESCRIPTION
Remove unused import of `@vaadin/vaadin-tabs` which causes issues when compiling with Vaadin 24