### PR TITLE
Vaadin profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,5 +146,18 @@
       </plugins>
     </pluginManagement>
   </build>
-  
+
+  <profiles>
+	<profile>
+		<id>v23</id>
+		<properties>
+			<vaadin.version>23.2.10</vaadin.version>
+			<maven.compiler.source>11</maven.compiler.source>
+			<maven.compiler.target>11</maven.compiler.target>
+		</properties>
+	</profile>
+	<profile>
+
+  </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,26 @@
 		</properties>
 	</profile>
 	<profile>
-
+		<id>v24</id>
+		<properties>
+			<vaadin.version>24.0.0.alpha5</vaadin.version>
+			<maven.compiler.source>17</maven.compiler.source>
+			<maven.compiler.target>17</maven.compiler.target>
+			<jetty.version>11.0.12</jetty.version>
+		</properties>
+		<repositories>
+			<repository>
+				<id>vaadin-prerelease</id>
+				<url>https://maven.vaadin.com/vaadin-prereleases</url>
+			</repository>
+		</repositories>
+		<pluginRepositories>
+			<pluginRepository>
+				<id>vaadin-prerelease</id>
+				<url>https://maven.vaadin.com/vaadin-prereleases</url>
+			</pluginRepository>
+		</pluginRepositories>
+	</profile>
   </profiles>
 
 </project>

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeView.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeView.java
@@ -21,11 +21,13 @@ package com.flowingcode.vaadin.addons.demo;
 
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
 
 @SuppressWarnings("serial")
 @JsModule("./code-viewer.ts")
+@NpmPackage(value = "lit", version = "2.5.0")
 class SourceCodeView extends Div implements HasSize {
 
   public SourceCodeView(String sourceUrl) {


### PR DESCRIPTION
Add `@NpmPackage` for `lit`, which seems to be necessary in Vaadin 14 after 1febde79
Also, add profiles for V23 and V24