### PR TITLE
fix: preserve source visibility if not mobile

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -271,7 +271,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     super.onAttach(attachEvent);
     getUI().ifPresent(ui -> ui.getPage().retrieveExtendedClientDetails(receiver -> {
       boolean mobile = receiver.getBodyClientWidth() <= MOBILE_DEVICE_BREAKPOINT_WIDTH;
-      codeCB.setValue(!mobile);
+      codeCB.setValue(codeCB.getValue() && !mobile);
 
       boolean portraitOrientation = receiver.getBodyClientHeight() > receiver.getBodyClientWidth();
       adjustSplitOrientation(portraitOrientation);


### PR DESCRIPTION
If `codeCB` is unchecked, and the screen resolution is not mobile, it should remain unchecked