### PR TITLE
feat: cleanup source snippets

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/code-viewer.ts
+++ b/src/main/resources/META-INF/resources/frontend/code-viewer.ts
@@ -197,7 +197,7 @@ pre[class*="language-"] {
       var code = self.querySelector("code") as HTMLElement;
       var text = self.removeLicense(this.responseText);
       code.setAttribute("class", "language-" + language);
-      code.innerHTML = self.escapeHtml(text);
+      code.innerHTML = self.escapeHtml(self.cleanupCode(text));
       
       (window as any).Prism.highlightAllUnder(self);
       self.__license.reverse().forEach(e=>self.querySelector('pre code')?.prepend(e));
@@ -241,6 +241,19 @@ pre[class*="language-"] {
       }
     } while (0);
     return text;
+  }
+  
+  cleanupCode(text: string) : string {
+    return text.split('\n').filter(line=> 
+       !line.match("//\\s*hide-source(\\s|$)")
+    && !line.startsWith('@Route')
+    && !line.startsWith('@PageTitle')
+    && !line.startsWith('@DemoSource')
+    && !line.startsWith('package ')
+    && line != 'import com.vaadin.flow.router.PageTitle;'
+    && line != 'import com.vaadin.flow.router.Route;'
+    && line != 'import com.flowingcode.vaadin.addons.demo.DemoSource;'
+    ).join('\n');
   }
   
   escapeHtml(unsafe: string) {

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
@@ -31,5 +31,6 @@ public class SampleDemoDefault extends Div {
 
   public SampleDemoDefault() {
     add(new Span("Demo component with defaulted @DemoSource annotation"));
+    this.getClass(); // hide-source (this line will not be displayed in the code snippet)
   }
 }


### PR DESCRIPTION
Remove the following boilerplate code from source snippets:

- The package declaration
- All lines with a `// hide-source` comment.
- The `@Route` annotation and its import.
- The `@PageTitle` annotation and its import.
- The `@DemoSource` annotation and its import.

![image](https://user-images.githubusercontent.com/11554739/225066351-7d21d5c6-85bc-406f-be05-0532a714156a.png)
