### PR TITLE
feat: add support for show-code and conditional code 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <vaadin.version>14.8.9</vaadin.version>
+    <vaadin.version>14.10.3</vaadin.version>
     <jetty.version>9.4.36.v20210114</jetty.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,32 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.1.2</version>
+            <configuration>
+                <!-- Generated file that shouldn't be included in add-ons -->
+                <excludes>
+                    <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
+                </excludes>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-maven-plugin</artifactId>
+            <version>${vaadin.version}</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-frontend</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeView.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeView.java
@@ -26,18 +26,28 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinService;
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 @JsModule("./code-viewer.ts")
 @NpmPackage(value = "lit", version = "2.5.0")
 class SourceCodeView extends Div implements HasSize {
 
+  private final Element codeViewer;
+
   public SourceCodeView(String sourceUrl) {
+    this(sourceUrl, null);
+  }
+
+  public SourceCodeView(String sourceUrl, Map<String, String> properties) {
     String url = translateSource(sourceUrl);
-    Element codeViewer = new Element("code-viewer");
+    codeViewer = new Element("code-viewer");
     getElement().appendChild(codeViewer);
     getElement().getStyle().set("display", "flex");
     codeViewer.getStyle().set("flex-grow", "1");
+    setProperties(properties);
     addAttachListener(
         ev -> {
           codeViewer.executeJs("this.fetchContents($0,$1)", url, "java");
@@ -57,5 +67,17 @@ class SourceCodeView extends Div implements HasSize {
       url = url.replaceFirst("/blob", "");
     }
     return url;
+  }
+
+  private void setProperties(Map<String, String> properties) {
+    if (properties != null) {
+      JsonObject env = Json.createObject();
+      properties.forEach((k, v) -> {
+        if (v != null) {
+          env.put(k, Json.create(v));
+        }
+      });
+      codeViewer.setPropertyJson("env", env);
+    }
   }
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -23,6 +23,9 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+import com.vaadin.flow.server.Version;
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("serial")
 class SplitLayoutDemo extends Composite<SplitLayout> {
@@ -31,8 +34,12 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
 
   public SplitLayoutDemo(Component demo, String sourceUrl) {
     getContent().setOrientation(Orientation.HORIZONTAL);
-    code = new SourceCodeView(sourceUrl);
 
+    Map<String, String> properties = new HashMap<>();
+    properties.put("vaadin", VaadinVersion.getVaadinVersion());
+    properties.put("flow", Version.getFullVersion());
+
+    code = new SourceCodeView(sourceUrl, properties);
     getContent().addToPrimary(demo);
     getContent().addToSecondary(code);
     getContent().setSizeFull();

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/VaadinVersion.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/VaadinVersion.java
@@ -1,0 +1,27 @@
+package com.flowingcode.vaadin.addons.demo;
+
+import com.vaadin.flow.server.Version;
+import java.util.Objects;
+import java.util.Properties;
+import org.slf4j.LoggerFactory;
+
+public class VaadinVersion {
+
+  private VaadinVersion() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static String getVaadinVersion() {
+    try {
+      Properties pom = new Properties();
+      pom.load(VaadinVersion.class
+          .getResourceAsStream("/META-INF/maven/com.vaadin/vaadin-core/pom.properties"));
+      return Objects.requireNonNull((String) pom.get("version"));
+    } catch (Exception e) {
+      LoggerFactory.getLogger(Version.class.getName())
+          .warn("Unable to determine Vaadin version number", e);
+      return null;
+    }
+  }
+
+}

--- a/src/main/resources/META-INF/resources/frontend/code-viewer.ts
+++ b/src/main/resources/META-INF/resources/frontend/code-viewer.ts
@@ -244,7 +244,10 @@ pre[class*="language-"] {
   }
   
   cleanupCode(text: string) : string {
-    return text.split('\n').filter(line=> 
+    return text.split('\n').map(line=>{
+        let m= line!.match("^(?<spaces>\\s*)//\\s*show-source\\s(?<line>.*)");
+        return m?m.groups!.spaces+m.groups!.line : line!;
+    }).filter(line=>
        !line.match("//\\s*hide-source(\\s|$)")
     && !line.startsWith('@Route')
     && !line.startsWith('@PageTitle')

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
@@ -33,5 +33,10 @@ public class SampleDemoDefault extends Div {
     add(new Span("Demo component with defaulted @DemoSource annotation"));
     // show-source System.out.println("this line will be displayed in the code snippet");
     this.getClass(); // hide-source (this line will not be displayed in the code snippet)
+    // #if vaadin ge 23
+    // show-source System.out.println("conditional code for Vaadin 23+");
+    // #elif vaadin ge 14
+    // show-source System.out.println("conditional code for Vaadin 14-22");
+    // #endif
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoDefault.java
@@ -31,6 +31,7 @@ public class SampleDemoDefault extends Div {
 
   public SampleDemoDefault() {
     add(new Span("Demo component with defaulted @DemoSource annotation"));
+    // show-source System.out.println("this line will be displayed in the code snippet");
     this.getClass(); // hide-source (this line will not be displayed in the code snippet)
   }
 }


### PR DESCRIPTION
show-source is implemented as described in #42 

Support for conditional code (#43) uses C-inspired directives `#if`, `#elif` (else-if), `#else` and `#endif`

Syntax: `#if variable operator value` 
- Supported variables are "vaadin" and "flow". (Note that Vaadin 14 uses Flox 1.x.x)
- Supported operators are `lt`, `le`, `ne`, `eq`, `gt`, `ge` (Operator names borrowed from Fortran)
- Value is a one-digit (`x`), two-digit (`x.y`) or three-digit (`x.y.z`) version number 

Implementation: The `cleanupCode` algorithm was improved in order to preprocess the sources before feeding them to prism.js. The implementation uses two stacks: a stack of guards (`guards`) and a stack of directives (the `stack`). Guards are three-valued: `istrue`, `isfalse` or `wastrue`. 

When an `#if` directive is found, it's immediately pushed onto the directives stack. `#elif` and `#else` directives replace the top of the directives stack, but only if we can transition into them (in order to avoid malformed blocks such as `if-else-else`); otherwise the top of stack is replaced with `error`, which can only be popped. `#endif` pops the stack.

When an `#if` directive is found, the condition is evaluated and the result is pushed onto `guards`. `#elif` and `#else` directives replace the top of the guards stack with the evaluation result (`#else` evaluates to `istrue`), but only if the top of the guards stack `isfalse`; otherwise they replace the top of stack with `wastrue`.  `#endif` pops the guards stack.

Directives are always removed from the rendered sources. Other lines (which are not directives) are removed if any guard in the stack `isfalse` or `wastrue`.
