### PR TITLE
Fix code-viewer __compare

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/code-viewer.ts
+++ b/src/main/resources/META-INF/resources/frontend/code-viewer.ts
@@ -354,8 +354,6 @@ pre[class*="language-"] {
          if (ai<bi) return -1;
          if (ai>bi) return +1;
      }
-     if (aa.length<bb.length) return -1;
-     if (aa.length>bb.length) return +1;
      return 0;
    }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
@@ -41,7 +41,7 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
     return method.replaceFirst("^test", "");
   }
 
-  protected void open(String... args) {
+  protected String open(String... args) {
     String resource = getResourceName();
 
     if (viewer != null) {
@@ -52,6 +52,7 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
     String params = Stream.of(args).map(Object::toString).collect(Collectors.joining(";"));
     getDriver().get(getURL(String.format("it/view/%s?src/test/resources/%s.java", params, path)));
     viewer = $(SourceCodeViewerElement.class).waitForFirst();
+    return viewer.getText();
   }
 
   private String getExpectedText(String resource) {
@@ -69,10 +70,6 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
 
   protected final String expected() {
     return getExpectedText(getResourceName());
-  }
-
-  protected String getText() {
-    return viewer.getText();
   }
 
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
@@ -36,11 +36,17 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
     super(null);
   }
 
-  protected void open(String resource, String... args) {
+  private String getResourceName() {
+    String method = new Throwable().getStackTrace()[2].getMethodName();
+    return method.replaceFirst("^test", "");
+  }
+
+  protected void open(String... args) {
+    String resource = getResourceName();
+
     if (viewer != null) {
       throw new IllegalStateException();
     }
-    expected = getExpectedText(resource);
 
     String path = "com/flowingcode/vaadin/addons/demo/it/" + resource;
     String params = Stream.of(args).map(Object::toString).collect(Collectors.joining(";"));
@@ -62,7 +68,7 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
   }
 
   protected final String expected() {
-    return expected;
+    return getExpectedText(getResourceName());
   }
 
   protected String getText() {

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/AbstractSourceCodeViewerIT.java
@@ -21,6 +21,7 @@ package com.flowingcode.vaadin.addons.demo.it;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.MissingResourceException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
@@ -47,8 +48,12 @@ public abstract class AbstractSourceCodeViewerIT extends AbstractViewTest {
     viewer = $(SourceCodeViewerElement.class).waitForFirst();
   }
 
-  private static String getExpectedText(String resource) {
-    InputStream in = AbstractSourceCodeViewerIT.class.getResourceAsStream(resource + ".txt");
+  private String getExpectedText(String resource) {
+    resource += ".txt";
+    InputStream in = this.getClass().getResourceAsStream(resource);
+    if (in == null) {
+      throw new MissingResourceException(resource, null, null);
+    }
     try {
       return new String(IOUtils.toByteArray(in), "UTF-8").trim().replaceAll("\r", "");
     } catch (IOException e) {

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/ConditionalSourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/ConditionalSourceCodeViewerIT.java
@@ -1,0 +1,39 @@
+package com.flowingcode.vaadin.addons.demo.it;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ConditionalSourceCodeViewerIT extends AbstractSourceCodeViewerIT {
+
+  private static final String VAADIN_VERSION = "vaadin=23.4.5";
+
+  @Test
+  public void testConditionEq() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+
+  @Test
+  public void testConditionNe() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+
+  @Test
+  public void testConditionLt() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+
+  @Test
+  public void testConditionLe() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+
+  @Test
+  public void testConditionGt() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+
+  @Test
+  public void testConditionGe() {
+    assertEquals(expected(), open(VAADIN_VERSION));
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/SourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/SourceCodeViewerIT.java
@@ -26,37 +26,37 @@ public class SourceCodeViewerIT extends AbstractSourceCodeViewerIT {
 
   @Test
   public void testSimpleSource() {
-    open("SimpleSource");
+    open();
     assertEquals(expected(), getText());
   }
 
   @Test
   public void testHideSource() {
-    open("HideSource");
+    open();
     assertEquals(expected(), getText());
   }
 
   @Test
   public void testShowSource() {
-    open("ShowSource");
+    open();
     assertEquals(expected(), getText());
   }
 
   @Test
   public void testPackageCleanup() {
-    open("PackageCleanup");
+    open();
     assertEquals(expected(), getText());
   }
 
   @Test
   public void testAnnotationCleanup() {
-    open("AnnotationCleanup");
+    open();
     assertEquals(expected(), getText());
   }
 
   @Test
   public void testLicenseCleanup() {
-    open("LicenseCleanup");
+    open();
     assertEquals(expected(), getText());
   }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/it/SourceCodeViewerIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/it/SourceCodeViewerIT.java
@@ -26,38 +26,32 @@ public class SourceCodeViewerIT extends AbstractSourceCodeViewerIT {
 
   @Test
   public void testSimpleSource() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
   @Test
   public void testHideSource() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
   @Test
   public void testShowSource() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
   @Test
   public void testPackageCleanup() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
   @Test
   public void testAnnotationCleanup() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
   @Test
   public void testLicenseCleanup() {
-    open();
-    assertEquals(expected(), getText());
+    assertEquals(expected(), open());
   }
 
 }

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionEq.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionEq.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin eq 22
+  // show-source eq 22
+  // #endif
+  // #if vaadin eq 23
+  // show-source eq 23
+  // #endif  
+  // #if vaadin eq 24
+  // show-source eq 24
+  // #endif
+  // #if vaadin eq 23.3
+  // show-source eq 23.3
+  // #endif
+  // #if vaadin eq 23.4
+  // show-source eq 23.4
+  // #endif
+  // #if vaadin eq 23.5
+  // show-source eq 23.5
+  // #endif  
+  // #if vaadin eq 23.4.4
+  // show-source eq 23.4.4
+  // #endif
+  // #if vaadin eq 23.4.5
+  // show-source eq 23.4.5
+  // #endif  
+  // #if vaadin eq 23.4.6
+  // show-source eq 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionEq.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionEq.txt
@@ -1,0 +1,5 @@
+class MyClass {
+  eq 23
+  eq 23.4
+  eq 23.4.5
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGe.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGe.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin ge 22
+  // show-source ge 22
+  // #endif
+  // #if vaadin ge 23
+  // show-source ge 23
+  // #endif  
+  // #if vaadin ge 24
+  // show-source ge 24
+  // #endif
+  // #if vaadin ge 23.3
+  // show-source ge 23.3
+  // #endif
+  // #if vaadin ge 23.4
+  // show-source ge 23.4
+  // #endif
+  // #if vaadin ge 23.5
+  // show-source ge 23.5
+  // #endif  
+  // #if vaadin ge 23.4.4
+  // show-source ge 23.4.4
+  // #endif
+  // #if vaadin ge 23.4.5
+  // show-source ge 23.4.5
+  // #endif  
+  // #if vaadin ge 23.4.6
+  // show-source ge 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGe.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGe.txt
@@ -1,0 +1,8 @@
+class MyClass {
+  ge 22
+  ge 23
+  ge 23.3
+  ge 23.4
+  ge 23.4.4
+  ge 23.4.5
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGt.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGt.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin gt 22
+  // show-source gt 22
+  // #endif
+  // #if vaadin gt 23
+  // show-source gt 23
+  // #endif  
+  // #if vaadin gt 24
+  // show-source gt 24
+  // #endif
+  // #if vaadin gt 23.3
+  // show-source gt 23.3
+  // #endif
+  // #if vaadin gt 23.4
+  // show-source gt 23.4
+  // #endif
+  // #if vaadin gt 23.5
+  // show-source gt 23.5
+  // #endif  
+  // #if vaadin gt 23.4.4
+  // show-source gt 23.4.4
+  // #endif
+  // #if vaadin gt 23.4.5
+  // show-source gt 23.4.5
+  // #endif  
+  // #if vaadin gt 23.4.6
+  // show-source gt 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGt.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionGt.txt
@@ -1,0 +1,5 @@
+class MyClass {
+  gt 22
+  gt 23.3
+  gt 23.4.4
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLe.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLe.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin le 22
+  // show-source le 22
+  // #endif
+  // #if vaadin le 23
+  // show-source le 23
+  // #endif  
+  // #if vaadin le 24
+  // show-source le 24
+  // #endif
+  // #if vaadin le 23.3
+  // show-source le 23.3
+  // #endif
+  // #if vaadin le 23.4
+  // show-source le 23.4
+  // #endif
+  // #if vaadin le 23.5
+  // show-source le 23.5
+  // #endif  
+  // #if vaadin le 23.4.4
+  // show-source le 23.4.4
+  // #endif
+  // #if vaadin le 23.4.5
+  // show-source le 23.4.5
+  // #endif  
+  // #if vaadin le 23.4.6
+  // show-source le 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLe.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLe.txt
@@ -1,0 +1,8 @@
+class MyClass {
+  le 23
+  le 24
+  le 23.4
+  le 23.5
+  le 23.4.5
+  le 23.4.6
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLt.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLt.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin lt 22
+  // show-source lt 22
+  // #endif
+  // #if vaadin lt 23
+  // show-source lt 23
+  // #endif  
+  // #if vaadin lt 24
+  // show-source lt 24
+  // #endif
+  // #if vaadin lt 23.3
+  // show-source lt 23.3
+  // #endif
+  // #if vaadin lt 23.4
+  // show-source lt 23.4
+  // #endif
+  // #if vaadin lt 23.5
+  // show-source lt 23.5
+  // #endif  
+  // #if vaadin lt 23.4.4
+  // show-source lt 23.4.4
+  // #endif
+  // #if vaadin lt 23.4.5
+  // show-source lt 23.4.5
+  // #endif  
+  // #if vaadin lt 23.4.6
+  // show-source lt 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLt.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionLt.txt
@@ -1,0 +1,5 @@
+class MyClass {
+  lt 24
+  lt 23.5
+  lt 23.4.6
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionNe.java
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionNe.java
@@ -1,0 +1,29 @@
+class MyClass {
+  // #if vaadin ne 22
+  // show-source ne 22
+  // #endif
+  // #if vaadin ne 23
+  // show-source ne 23
+  // #endif  
+  // #if vaadin ne 24
+  // show-source ne 24
+  // #endif
+  // #if vaadin ne 23.3
+  // show-source ne 23.3
+  // #endif
+  // #if vaadin ne 23.4
+  // show-source ne 23.4
+  // #endif
+  // #if vaadin ne 23.5
+  // show-source ne 23.5
+  // #endif  
+  // #if vaadin ne 23.4.4
+  // show-source ne 23.4.4
+  // #endif
+  // #if vaadin ne 23.4.5
+  // show-source ne 23.4.5
+  // #endif  
+  // #if vaadin ne 23.4.6
+  // show-source ne 23.4.6
+  // #endif    
+}

--- a/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionNe.txt
+++ b/src/test/resources/com/flowingcode/vaadin/addons/demo/it/ConditionNe.txt
@@ -1,0 +1,8 @@
+class MyClass {
+  ne 22
+  ne 24
+  ne 23.3
+  ne 23.5
+  ne 23.4.4
+  ne 23.4.6
+}


### PR DESCRIPTION
The current implementation of version comparison in #44 follows a lexicographic order, yielding consistent yet non-intuitive outcomes (`23.0.0` is greater than `23` and `23.0.0` is not equal to `23`)

https://github.com/FlowingCode/CommonsDemo/blob/ef035156d29c5a63227d8bb472717f510afbf711/src/main/resources/META-INF/resources/frontend/code-viewer.ts#L348-L359

Instead, we should only compare the provided digits, so that `23.0.0` is _not_ greater than `23`, and `23.1.0` is _equals_ to 23.
```diff
-    if (aa.length<bb.length) return -1; 
-    if (aa.length>bb.length) return +1; 
    return 0; 
```

Strictly, "equals" will be implemented as "is contained in" (23.0.0 is-contained-in 23) and "greater-or-equal" will be implemented as "precedes or is contained in" ("23.4.5 precedes 24", 23.4.5 "precedes or is contained in 23"), thus "equality" will not be transitive, but I think we can keep the usual operator names because they are intuitive.
