### PR TITLE
Add support for highlighting source code fragments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.flowingcode.vaadin.addons.demo</groupId>
   <artifactId>commons-demo</artifactId>
-  <version>3.7.2-SNAPSHOT</version>
+  <version>3.8.0-SNAPSHOT</version>
   
   <name>Commons Demo</name>
   <description>Common classes for add-ons demo</description>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
                 <webAppConfig>
                     <resourceBases>
                         <resourceBase>src/main/resources/META-INF/resources</resourceBase>
+                        <resourceBase>src/test/resources/META-INF/resources</resourceBase>
                     </resourceBases>
                 </webAppConfig>
             </configuration>

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
@@ -20,7 +20,9 @@
 package com.flowingcode.vaadin.addons.demo;
 
 import com.flowingcode.vaadin.addons.DevSourceRequestHandler;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
@@ -80,4 +82,15 @@ public class SourceCodeViewer extends Div implements HasSize {
       codeViewer.setPropertyJson("env", env);
     }
   }
+
+  public static void highlightOnHover(Component c, String id) {
+    c.addAttachListener(ev -> {
+      c.getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlightOnHover(this,$0)", id);
+    });
+  }
+
+  public static void highlight(String id) {
+    UI.getCurrent().getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlight($0)", id);
+  }
+
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/Demo.java
@@ -32,6 +32,7 @@ public class Demo extends TabbedDemo {
     addDemo(new LegacyDemo());
     addDemo(SampleDemo.class, "Demo");
     addDemo(SampleDemoDefault.class);
+    addDemo(SampleDemoHighlight.class);
     addDemo(AdHocDemo.class);
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoHighlight.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/SampleDemoHighlight.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2023 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "demo/highlight", layout = Demo.class)
+@PageTitle("Highlight")
+@DemoSource
+@StyleSheet("./highlight-demo.css")
+public class SampleDemoHighlight extends Div {
+
+  public SampleDemoHighlight() {
+    add(new Span("Highlight source fragments"));
+
+    // begin-block first
+    Div first = new Div(new Text("First"));
+    SourceCodeViewer.highlightOnHover(first, "first");
+    first.addClassName("dashed"); // hide-source
+    add(first);
+    // end-block
+
+    // begin-block second
+    Div second = new Div(new Text("Second"));
+    SourceCodeViewer.highlightOnHover(second, "second");
+    second.addClassName("dashed"); // hide-source
+    add(second);
+    // end-block
+
+    HorizontalLayout hl = new HorizontalLayout();
+
+    // begin-block button
+    hl.add(new Button("Click me", ev -> {
+      SourceCodeViewer.highlight("button");
+    }));
+    // end-block
+
+    hl.add(new Button("Highlight Off", ev -> {
+      SourceCodeViewer.highlight(null);
+    }));
+
+    add(hl);
+  }
+}

--- a/src/test/resources/META-INF/resources/frontend/highlight-demo.css
+++ b/src/test/resources/META-INF/resources/frontend/highlight-demo.css
@@ -1,0 +1,9 @@
+.dashed {
+	border: 1px dashed black;
+	padding: 1ex;
+	margin: 1ex;
+}
+
+.dashed:hover {
+    background: var(--lumo-contrast-10pct);
+}


### PR DESCRIPTION
Add support for highlighting source code fragments in order to emphasize a section of the code snippet. A block is delimited by `// begin-block name` and `// end-block` comments. Nested blocks are not supported.

```
    // begin-block first
    Div first = new Div(new Text("First"));
    SourceCodeViewer.highlightOnHover(first, "first");
    first.addClassName("dashed"); // hide-source
    add(first);
    // end-block
```
![image](https://github.com/FlowingCode/CommonsDemo/assets/11554739/02063272-029f-4b4b-bd6f-821f2f8a0158)

