### PR TITLE
ci: add GPG settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,33 @@
   </build>
 
   <profiles>
+    <profile>
+        <id>gpg</id>
+        <activation>
+            <property>
+                <name>gpg.passphrase</name>
+            </property>
+        </activation>
+        <build>
+            <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+  </profile>
+
 	<profile>
 		<id>v23</id>
 		<properties>


### PR DESCRIPTION
Plugins cannot be _added_ in external settings.xml files. The external configuration was ignored (gpg:sign did never bind to the verify phase) but it ran because I had changed the goals to `clean package gpg:sign deploy`. 

In order to integrate with the release plugin, I think it's better that we define a profile with implicit activation (if the GPG passphrase is provided), so that the goal is just `clean deploy` using default settings.xml.