### PR TITLE
fix: improve autoscroll to highlighted block

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/code-viewer.ts
+++ b/src/main/resources/META-INF/resources/frontend/code-viewer.ts
@@ -449,12 +449,16 @@ pre[class*="language-"] {
             div.style.top= `calc( ${top}px + 0.75em)`;
             div.style.height= `${height}px`;
             
-            //scroll to the begin of the marked block
-            if ((begin as any).scrollIntoViewIfNeeded) {
-                (begin as any).scrollIntoViewIfNeeded();
-            }  else {
-                (begin as any).scrollIntoView()
+            const scrollIntoView = elem => {
+                if ((elem as any).scrollIntoViewIfNeeded) {
+                    (elem as any).scrollIntoViewIfNeeded();
+                }  else {
+                    (elem as any).scrollIntoView()
+                }
             }
+            
+            scrollIntoView(end);
+            scrollIntoView(begin);
         }
     }
   }


### PR DESCRIPTION
Scroll to the last line before scrolling to the first line, so that the whole block is moved into view (which improves the behavior when the first line was already visible while the last lines aren't)

![image](https://github.com/FlowingCode/CommonsDemo/assets/11554739/e088d605-8e12-4dc7-91e5-7434dee49ac1)
