### PR TITLE
feat: add support for multiple source highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,18 +166,21 @@ Strictly, the constructor of `SourceCodeViewer` receives a map with arbitrary va
 This feature supports highlighting a source code fragment in order to emphasize a section of the code snippet.
 The highlighted fragment is automatically scrolled into view.
 
-A fragment is highlighted either by calling `SourceCodeViewer.highlight(name)` or when hovering a component that has been configured with `SourceCodeViewer.highlightOnHover(component,name)`, where `name` is the name of the fragment. `SourceCodeViewer.highlight(null)` turn off the highlighting.
-`SourceCodeViewer.highlightOnClick` allows configuring a click listener that turns highlight on.
+A fragment is highlighted either by calling `SourceCodeViewer.highlight(filenameAndId)` or when clicking/hovering a component that has been configured with `SourceCodeViewer.highlightOnClick` or `SourceCodeViewer.highlightOnHover`, where `filenameAndId` is the name of the fragment. If the component is in an additional source file, `filenameAndId` can be given as a string in the format `filename#id`. If no `'#'` is present, it is assumed that the identifier corresponds to a block in the first source panel. `SourceCodeViewer.highlight(null)` turns off the highlighting.
 
-In the source code, a fragment is delimited by `// begin-block name` and `// end-block` comments. Nested fragments are not supported.
+In the source code, a fragment is delimited by `// begin-block filenameAndId` and `// end-block` comments. Nested fragments are not supported.
 The `// begin-block` and `// end-block` comments are removed after post-processing.
 
 ```
     // begin-block first
-    Div first = new Div(new Text("First"));
+    Div first = new Div(new Text("Highlight block in first panel"));
     SourceCodeViewer.highlightOnHover(first, "first");
     add(first);
     // end-block
+    
+    Div other = new Div(new Text("Highlight additional source"));
+    SourceCodeViewer.highlightOnHover(other, "AdditionalSource.java#other");
+    add(other);
 ```
 
 <!-- FROM https://github.com/FlowingCode/CommonsDemo/pull/62 -->

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
@@ -4,6 +4,7 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
+import elemental.json.JsonValue;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,8 +27,9 @@ public class MultiSourceCodeViewer extends Div {
       selectedTab = tabs.getSelectedTab();
 
       getElement().addEventListener("fragment-request", ev -> {
-        String filename = ev.getEventData().get("event.detail.filename").asString();
-        findTabWithFilename(filename).ifPresent(tab -> {
+        JsonValue filename = ev.getEventData().get("event.detail.filename");
+        findTabWithFilename(Optional.ofNullable(filename).map(JsonValue::asString).orElse(null))
+            .ifPresent(tab -> {
           tabs.setSelectedTab(tab);
         });
       }).addEventData("event.detail.filename");

--- a/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
@@ -89,20 +89,54 @@ public class SourceCodeViewer extends Div implements HasSize {
     }
   }
 
-  public static void highlightOnHover(Component c, String id) {
+  /**
+   * Highlights the block identified by {@code filenameAndId} when the component is hovered over.
+   * <p>
+   * If the component is in an additional source, {@code filenameAndId} can be given as a string in
+   * the format {@code filename#id}. If no {@code '#'} is present, it is assumed that the identifier
+   * corresponds to a block in the first source panel.
+   *
+   * @param c The component that triggers the highlight action when hovered over.
+   * @param filenameAndId The identifier string that combines filename and id separated by
+   *        {@code '#'}.
+   */
+  public static void highlightOnHover(Component c, String filenameAndId) {
     c.addAttachListener(ev -> {
-      c.getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlightOnHover(this,$0)", id);
+      c.getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlightOnHover(this,$0)", filenameAndId);
     });
   }
 
-  public static <T extends HasElement & ClickNotifier<?>> void highlightOnClick(T c, String id) {
+  /**
+   * Highlight block {@code id} when the component is clicked.
+   * <p>
+   * If the component is in an additional source, {@code filenameAndId} can be given as a string in
+   * the format {@code filename#id}. If no {@code '#'} is present, it is assumed that the identifier
+   * corresponds to a block in the first source panel.
+   *
+   * @param c The component that triggers the highlight action when clicked.
+   * @param filenameAndId The identifier string that combines filename and id separated by
+   *        {@code '#'}.
+   */
+  public static <T extends HasElement & ClickNotifier<?>> void highlightOnClick(T c,
+      String filenameAndId) {
     c.addClickListener(ev -> {
-      c.getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlight($0)", id);
+      c.getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlight($0)", filenameAndId);
     });
   }
 
-  public static void highlight(String id) {
-    UI.getCurrent().getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlight($0)", id);
+  /**
+   * Highlights the block identified by {@code filenameAndId}.
+   * <p>
+   * If the component is in an additional source, {@code filenameAndId} can be given as a string in
+   * the format {@code filename#id}. If no {@code '#'} is present, it is assumed that the identifier
+   * corresponds to a block in the first source panel.
+   *
+   * @param filenameAndId The identifier string that combines filename and id separated by
+   *        {@code '#'}.
+   */
+
+  public static void highlight(String filenameAndId) {
+    UI.getCurrent().getElement().executeJs("Vaadin.Flow.fcCodeViewerConnector.highlight($0)", filenameAndId);
   }
 
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/AdditionalSources.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/AdditionalSources.java
@@ -1,0 +1,7 @@
+package com.flowingcode.vaadin.addons.demo;
+
+public class AdditionalSources {
+  // begin-block fragment
+  // this class has more sources
+  // end-block fragment
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/demo/MultiSourceDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/demo/MultiSourceDemo.java
@@ -18,26 +18,34 @@
  */
 package com.flowingcode.vaadin.addons.demo;
 
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "demo/multisource", layout = Demo.class)
 @PageTitle("Demo with multiple sources")
 // show-source @DemoSource
+// show-source @DemoSource(clazz = AdditionalSources.class)
 // show-source @DemoSource("/src/test/resources/META-INF/resources/frontend/multi-source-demo.css")
-// show-source @DemoSource(clazz = Demo.class)
 @DemoSource
+@DemoSource(clazz = AdditionalSources.class)
 @DemoSource("/src/test/resources/META-INF/resources/frontend/multi-source-demo.css")
-@DemoSource(clazz = Demo.class)
 @StyleSheet("./multi-source-demo.css")
 public class MultiSourceDemo extends Div {
   public MultiSourceDemo() {
-    Span span = new Span("This is the main source");
-    span.addClassName("custom-style");
-    add(span);
+
+    // begin-block main
+    Div div = new Div("This is the main source");
+    div.addClassName("custom-style");
+    SourceCodeViewer.highlightOnHover(div, "main");
+    add(div);
+    // end-block
+
+    Button button1 = new Button("Highlight code in AdditionalSources");
+    SourceCodeViewer.highlightOnClick(button1, "AdditionalSources.java#fragment");
+    add(button1);
   }
 
 }


### PR DESCRIPTION
Close #96

A fragment is highlighted either by calling `SourceCodeViewer.highlight(filenameAndId)` or when clicking/hovering a component that has been configured with `SourceCodeViewer.highlightOnClick` or `SourceCodeViewer.highlightOnHover`, where `filenameAndId` is the name of the fragment. If the component is in an additional source file, `filenameAndId` can be given as a string in the format `filename#id`. If no `'#'` is present, it is assumed that the identifier corresponds to a block in the first source panel.