### PR TITLE
feat: make DefaultSourceUrlResolver public

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/demo/DefaultSourceUrlResolver.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/demo/DefaultSourceUrlResolver.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  *
  * @author Javier Godoy / Flowing Code
  */
-class DefaultSourceUrlResolver implements SourceUrlResolver {
+public class DefaultSourceUrlResolver implements SourceUrlResolver {
 
   @Override
   public Optional<String> resolveURL(TabbedDemo demo, Class<?> annotatedClass,


### PR DESCRIPTION
Make `DefaultSourceUrlResolver` public, so that it can be extended in demo applications (see https://github.com/FlowingCode/AddonsDemo/issues/375)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API accessibility by making a core resolver class publicly available for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->