### PR TITLE
refactor: add method that receives class instead of instance

### DIFF
--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DefaultSourceUrlResolver.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DefaultSourceUrlResolver.java
@@ -40,6 +40,11 @@ public class DefaultSourceUrlResolver implements SourceUrlResolver {
   @Override
   public Optional<String> resolveURL(TabbedDemo demo, Class<?> annotatedClass,
       DemoSource annotation) {
+    return resolveURL(demo.getClass(), annotatedClass, annotation);
+  }
+
+  public Optional<String> resolveURL(Class<? extends TabbedDemo> viewClass, Class<?> annotatedClass,
+      DemoSource annotation) {
     String demoFile;
     String url = annotation.value();
     if (url.equals(DemoSource.DEFAULT_VALUE)) {
@@ -57,8 +62,8 @@ public class DefaultSourceUrlResolver implements SourceUrlResolver {
     }
 
     if (demoFile != null) {
-      String branch = TabbedDemo.lookupGithubBranch(demo.getClass());
-      return Optional.ofNullable(demo.getClass().getAnnotation(GithubLink.class))
+      String branch = TabbedDemo.lookupGithubBranch(viewClass);
+      return Optional.ofNullable(viewClass.getAnnotation(GithubLink.class))
           .map(githubLink -> String.format("%s/blob/%s/%s", githubLink.value(), branch, demoFile));
     } else {
       return Optional.empty();


### PR DESCRIPTION
While the source URL resolver only requires the class type rather than a concrete instance, updating the interface would introduce a breaking change. Consequently, this refactor is being implemented specifically to facilitate unit testing without disrupting the public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved source URL resolution mechanism for demo views by enhancing method delegation and class parameter handling to ensure more reliable URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->