### PR TITLE
feat: implement collapse/flip/rotate as buttons AND feat: add commons-demo iconset

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.flowingcode.vaadin.addons.demo</groupId>
   <artifactId>commons-demo</artifactId>
-  <version>5.3.2-SNAPSHOT</version>
+  <version>5.4.0-SNAPSHOT</version>
   
   <name>Commons Demo</name>
   <description>Common classes for add-ons demo</description>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -75,6 +75,12 @@
       <artifactId>vaadin-core</artifactId>
       <optional>true</optional>
     </dependency>
+    
+    <dependency>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin</artifactId>
+        <scope>test</scope>
+    </dependency>
         
     <dependency>
 		<groupId>org.projectlombok</groupId>
@@ -99,13 +105,13 @@
     <dependency>
         <groupId>com.flowingcode.vaadin</groupId>
         <artifactId>json-migration-helper</artifactId>
-        <version>0.9.2</version>
+        <version>0.9.5</version>
     </dependency>
     
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     
@@ -126,7 +132,14 @@
             </exclusion>
         </exclusions>
     </dependency>
-    
+
+    <dependency>
+        <groupId>com.flowingcode.vaadin.test</groupId>
+        <artifactId>testbench-rpc</artifactId>
+        <version>1.5.0</version>
+        <scope>test</scope>
+    </dependency>
+
     <dependency>
         <groupId>io.github.bonigarcia</groupId>
         <artifactId>webdrivermanager</artifactId>

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/CommonsDemoIcons.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/CommonsDemoIcons.java
@@ -29,7 +29,7 @@ import java.util.Locale;
  * @author Javier Godoy / Flowing Code
  */
 public enum CommonsDemoIcons implements IconFactory {
-  ROTATE, FLIP, HIDE_SOURCE, SHOW_SOURCE;
+  ROTATE, FLIP, HIDE_SOURCE, SHOW_SOURCE, GITHUB, HOME;
 
   /**
    * The Iconset name, i.e. {@code "commons-demo"}.

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/CommonsDemoIcons.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/CommonsDemoIcons.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo;
+
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.icon.IconFactory;
+import java.util.Locale;
+
+/**
+ * CommonsDemo icons.
+ *
+ * @author Javier Godoy / Flowing Code
+ */
+public enum CommonsDemoIcons implements IconFactory {
+  ROTATE, FLIP, HIDE_SOURCE, SHOW_SOURCE;
+
+  /**
+   * The Iconset name, i.e. {@code "commons-demo"}.
+   */
+  public static final String ICONSET = "commons-demo";
+
+  /**
+   * Return the full icon name.
+   *
+   * @return the full icon name, i.e. {@code "commons-demo:name"}.
+   */
+  public String getIconName() {
+    return ICONSET + ':' + getIconPart();
+  }
+
+  /**
+   * Return the icon name within the iconset.
+   *
+   * @return the icon name, i.e. {@code "name"}.
+   */
+  public String getIconPart() {
+    return name().toLowerCase(Locale.ENGLISH).replace('_', '-').replaceFirst("^-", "");
+  }
+
+  /**
+   * Create a new {@link Icon} instance with the icon determined by the name.
+   *
+   * @return a new instance of {@link Icon} component
+   */
+  @Override
+  public Icon create() {
+    return new Icon(getIconPart());
+  }
+
+  /**
+   * Server side component for CommonsDemo icons.
+   */
+  @JsModule("./commons-demo-iconset.ts")
+  @SuppressWarnings("serial")
+  public static final class Icon extends com.vaadin.flow.component.icon.Icon {
+    private Icon(String icon) {
+      super(ICONSET, icon);
+    }
+  }
+
+}

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
@@ -22,6 +22,7 @@ package com.flowingcode.vaadin.addons.demo;
 import com.flowingcode.vaadin.addons.GithubBranch;
 import com.flowingcode.vaadin.addons.GithubLink;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -44,6 +45,7 @@ import java.lang.annotation.Target;
 @Repeatable(DemoSources.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 public @interface DemoSource {
 
   static final String DEFAULT_VALUE = "__DEFAULT__";

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSource.java
@@ -76,8 +76,13 @@ public @interface DemoSource {
    */
   String language() default DEFAULT_VALUE;
 
-  /** Source code position in the layout */
-  SourcePosition sourcePosition() default SourcePosition.SECONDARY;
+  /**
+   * Source code position in the layout. Defaults to {@link SourcePosition#DEFAULT}, which adopts the
+   * position carried over from the previously shown demo, or {@link SourcePosition#SECONDARY} if
+   * there is none. An explicit {@link SourcePosition#PRIMARY} or {@link SourcePosition#SECONDARY}
+   * always takes precedence over the carried-over position.
+   */
+  SourcePosition sourcePosition() default SourcePosition.DEFAULT;
 
   String condition() default "";
 

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSources.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DemoSources.java
@@ -20,12 +20,14 @@
 package com.flowingcode.vaadin.addons.demo;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Inherited
 public @interface DemoSources {
 
   DemoSource[] value();

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DynamicTheme.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DynamicTheme.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.flowingcode.vaadin.addons.demo;
 
 import com.vaadin.flow.component.Component;

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/DynamicThemeInitializer.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/DynamicThemeInitializer.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.flowingcode.vaadin.addons.demo;
 
 import com.vaadin.flow.server.ServiceInitEvent;

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
@@ -76,6 +76,20 @@ public class MultiSourceCodeViewer extends Div {
     getStyle().set("flex-direction", "column");
   }
 
+  /**
+   * Adds the overlay controls to the underlying source code viewer. See
+   * {@link SourceCodeViewer#withButtons()} for the events they fire and the coordination they
+   * require from the enclosing layout.
+   *
+   * @return this viewer, for method chaining
+   */
+  public MultiSourceCodeViewer withButtons() {
+    if (codeViewer != null) {
+      codeViewer.withButtons();
+    }
+    return this;
+  }
+
   public boolean isEmpty() {
     return selectedTab == null;
   }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/MultiSourceCodeViewer.java
@@ -162,7 +162,7 @@ public class MultiSourceCodeViewer extends Div {
     if (selectedTab != null) {
       return (SourcePosition) ComponentUtil.getData(selectedTab, DATA_POSITION);
     } else {
-      return SourcePosition.SECONDARY;
+      return SourcePosition.DEFAULT;
     }
 
   }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SourceCodeViewer.java
@@ -37,10 +37,13 @@ import lombok.experimental.ExtensionMethod;
 
 @SuppressWarnings("serial")
 @JsModule("./code-viewer.ts")
+@JsModule("./source-code-viewer-buttons.ts")
 @ExtensionMethod(value = JsonMigration.class, suppressBaseMethods = true)
 public class SourceCodeViewer extends Div implements HasSize {
 
   private final Element codeViewer;
+
+  private final Div buttonsWrapper;
 
   public SourceCodeViewer(String sourceUrl) {
     this(sourceUrl, null);
@@ -51,13 +54,108 @@ public class SourceCodeViewer extends Div implements HasSize {
   }
 
   public SourceCodeViewer(String url, String language, Map<String, String> properties) {
+    addClassName("source-code-viewer");
+    addClassName("has-code-viewer-gutter");
+
     codeViewer = new Element("code-viewer");
-    getElement().appendChild(codeViewer);
-    getElement().getStyle().set("overflow", "auto");
-    getElement().getStyle().set("display", "flex");
-    codeViewer.getStyle().set("flex-grow", "1");
+
+    Div codeViewerWrapper = new Div();
+    codeViewerWrapper.addClassName("source-code-viewer-codeviewer-wrapper");
+    codeViewerWrapper.getElement().appendChild(codeViewer);
+
+    // Non-scrolling overlay so the buttons stay pinned while the code scrolls
+    buttonsWrapper = new Div();
+    buttonsWrapper.addClassName("source-code-viewer-buttons-wrapper");
+
+    add(codeViewerWrapper, buttonsWrapper);
+
     setProperties(properties);
-    addAttachListener(ev -> fetchContents(url, language));
+    addAttachListener(ev -> {
+      fetchContents(url, language);
+      observeScrollbar();
+    });
+  }
+
+  /**
+   * Adds the overlay controls (show, hide, flip and rotate) pinned over the source code.
+   * <p>
+   * The buttons do not change this viewer directly. Instead, each one dispatches a bubbling DOM
+   * event that is expected to be handled by an enclosing layout, which is what actually collapses,
+   * repositions or reorients the source panel:
+   * <ul>
+   * <li>show / hide dispatch {@code source-collapse-changed} (carrying {@code detail.collapsed});
+   * <li>flip dispatches {@code source-flip};
+   * <li>rotate dispatches {@code source-rotate}.
+   * </ul>
+   * The buttons are therefore only useful when this viewer is placed inside a layout that listens
+   * for those events and coordinates the response (see {@link TabbedDemo}); otherwise they emit
+   * events that nothing consumes.
+   * <p>
+   * The controls are rendered by the {@code source-code-viewer-buttons} client-side web component,
+   * which dispatches the events locally on click; the enclosing layout (see {@link TabbedDemo})
+   * handles them through Vaadin server-side listeners. This method is idempotent: the component is
+   * added only once.
+   */
+  public void withButtons() {
+    if (buttonsWrapper.getElement().getChildCount() == 0) {
+      buttonsWrapper.getElement().appendChild(new Element("source-code-viewer-buttons"));
+    }
+  }
+
+  /**
+   * Observes the scrollable wrapper. Whenever the vertical scrollbar appears or disappears, sets (or
+   * clears) the {@code --code-viewer-gutter} custom property on the nearest ancestor (or self)
+   * carrying the {@code has-code-viewer-gutter} class. Whenever the wrapper collapses below 24px in
+   * width or 10px in height, sets {@code --source-code-viewer-show-button-display} so the show
+   * button becomes visible (and clears it otherwise).
+   */
+  private void observeScrollbar() {
+    getElement().executeJs(
+        """
+        const root = this;
+        const wrapper = root.querySelector('.source-code-viewer-codeviewer-wrapper');
+        if (!wrapper) return;
+        root.__scrollbarObserver?.disconnect();
+        root.__scrollbarMutation?.disconnect();
+        let hasScrollbar = null;
+        const update = () => {
+          if (wrapper.offsetWidth < 24 || wrapper.offsetHeight < 10) {
+            root.style.setProperty('--source-code-viewer-show-button-display', 'block');
+          } else {
+            root.style.removeProperty('--source-code-viewer-show-button-display');
+          }
+          const current = wrapper.scrollHeight > wrapper.clientHeight;
+          if (current === hasScrollbar) return;
+          hasScrollbar = current;
+          let target = root;
+          while (target && !target.classList.contains('has-code-viewer-gutter')) {
+            target = target.parentElement;
+          }
+          if (target) {
+            if (current) {
+              const scrollbarWidth = wrapper.offsetWidth - wrapper.clientWidth;
+              target.style.setProperty('--code-viewer-gutter', scrollbarWidth + 'px');
+            } else {
+              target.style.removeProperty('--code-viewer-gutter');
+            }
+          }
+        };
+        let frame = 0;
+        const scheduleUpdate = () => {
+          if (frame) return;
+          frame = requestAnimationFrame(() => { frame = 0; update(); });
+        };
+        const resizeObserver = new ResizeObserver(scheduleUpdate);
+        resizeObserver.observe(wrapper);
+        root.__scrollbarObserver = resizeObserver;
+        const codeViewer = root.querySelector('code-viewer');
+        if (codeViewer) {
+          const mutationObserver = new MutationObserver(scheduleUpdate);
+          mutationObserver.observe(codeViewer, {childList: true, subtree: true});
+          root.__scrollbarMutation = mutationObserver;
+        }
+        update();
+        """);
   }
 
   public void fetchContents(String url, String language) {

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SourcePosition.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SourcePosition.java
@@ -21,15 +21,17 @@ package com.flowingcode.vaadin.addons.demo;
 
 public enum SourcePosition {
 
-  PRIMARY, SECONDARY;
+  PRIMARY, SECONDARY, DEFAULT;
 
   public SourcePosition toggle() {
     switch (this) {
       case SECONDARY:
+      case DEFAULT:
         return PRIMARY;
       case PRIMARY:
-      default:
         return SECONDARY;
+      default:
+        return this;
     }
   }
 

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -97,18 +97,18 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
     getContent().setSizeFull();
   }
 
-  public void showSourceCode() {
-    getContent().setSplitterPosition(50);
-  }
-
-  public void hideSourceCode() {
-    switch (sourcePosition) {
-      case PRIMARY:
-        getContent().setSplitterPosition(0);
-        break;
-      case SECONDARY:
-        getContent().setSplitterPosition(100);
-        break;
+  public void setSourceCollapsed(boolean collapsed) {
+    if (!collapsed) {
+      getContent().setSplitterPosition(50);
+    } else {
+      switch (sourcePosition) {
+        case PRIMARY:
+          getContent().setSplitterPosition(0);
+          break;
+        case SECONDARY:
+          getContent().setSplitterPosition(100);
+          break;
+      }
     }
   }
 

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -59,7 +59,11 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
     return code.isEmpty();
   }
 
-  private void setSourcePosition(SourcePosition position) {
+  public SourcePosition getSourcePosition() {
+    return sourcePosition;
+  }
+
+  public void setSourcePosition(SourcePosition position) {
     if (!position.equals(sourcePosition)) {
       getContent().removeAll();
       switch (position) {
@@ -74,10 +78,6 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
       }
       sourcePosition = position;
     }
-  }
-
-  public void toggleSourcePosition() {
-    setSourcePosition(sourcePosition.toggle());
   }
 
   public void setOrientation(Orientation o) {

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -93,10 +93,6 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
     return getContent().getOrientation();
   }
 
-  public void setSplitterPosition(int pos) {
-    getContent().setSplitterPosition(pos);
-  }
-
   public void setSizeFull() {
     getContent().setSizeFull();
   }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -106,8 +106,8 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
           getContent().setSplitterPosition(0);
           break;
         case SECONDARY:
+        default:
           getContent().setSplitterPosition(100);
-          break;
       }
     }
   }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/SplitLayoutDemo.java
@@ -48,7 +48,7 @@ class SplitLayoutDemo extends Composite<SplitLayout> {
     properties.put("vaadin", VaadinVersion.getVaadinVersion());
     properties.put("flow", Version.getFullVersion());
 
-    code = new MultiSourceCodeViewer(tabs, properties);
+    code = new MultiSourceCodeViewer(tabs, properties).withButtons();
     this.demo = demo;
     setSourcePosition(code.getSourcePosition());
 

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -78,7 +78,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
   private Checkbox themeCB;
-  private Orientation splitOrientation;
   private Button helperButton;
   private DemoHelperViewer demoHelperViewer;
 
@@ -221,6 +220,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     List<SourceCodeTab> sourceTabs = new ArrayList<>(demoSources.length);
     for (DemoSource demoSource : demoSources) {
       createSourceCodeTab(demo.getClass(), demoSource).ifPresent(sourceTabs::add);
+    }
+
+    Orientation splitOrientation = null;
+    if (currentLayout != null) {
+      splitOrientation = currentLayout.getOrientation();
     }
 
     if (!sourceTabs.isEmpty()) {
@@ -376,6 +380,8 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     if (currentLayout == null) {
       return;
     }
+
+    Orientation splitOrientation = getOrientation();
     if (Orientation.HORIZONTAL.equals(splitOrientation)) {
       splitOrientation = Orientation.VERTICAL;
     } else {
@@ -403,12 +409,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   }
 
   private void setOrientation(Orientation orientation, boolean fromClient) {
-    splitOrientation = orientation;
-    if (currentLayout != null) {
-      currentLayout.setOrientation(orientation);
-      currentLayout.setSplitterPosition(50);
+    if (currentLayout != null && orientation != getOrientation()) {
+        currentLayout.setOrientation(orientation);
+        currentLayout.showSourceCode();
+        fireOrientationChangedEvent(orientation, fromClient);
     }
-    fireOrientationChangedEvent(orientation, fromClient);
   }
 
   /**
@@ -534,11 +539,10 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private void adjustSplitOrientation(boolean portraitOrientation) {
     if (portraitOrientation) {
-      splitOrientation = Orientation.VERTICAL;
+      setOrientation(Orientation.VERTICAL);
     } else {
-      splitOrientation = Orientation.HORIZONTAL;
+      setOrientation(Orientation.HORIZONTAL);
     }
-    setOrientation(splitOrientation);
   }
 
   /**

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -78,7 +78,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
   private Checkbox themeCB;
-  private Orientation splitOrientation;
   private Button helperButton;
   private DemoHelperViewer demoHelperViewer;
 
@@ -223,6 +222,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
       createSourceCodeTab(demo.getClass(), demoSource).ifPresent(sourceTabs::add);
     }
 
+    Orientation splitOrientation = null;
+    if (currentLayout != null) {
+      splitOrientation = currentLayout.getOrientation();
+    }
+
     if (!sourceTabs.isEmpty()) {
       currentLayout = new SplitLayoutDemo(demo, sourceTabs);
       if (currentLayout.isEmpty()) {
@@ -326,11 +330,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private void updateSplitterPosition() {
     if (currentLayout != null) {
-      if (sourceCollapsed) {
-        currentLayout.hideSourceCode();
-      } else {
-        currentLayout.showSourceCode();
-      }
+      currentLayout.setSourceCollapsed(sourceCollapsed);
     }
   }
 
@@ -376,6 +376,8 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     if (currentLayout == null) {
       return;
     }
+
+    Orientation splitOrientation = getOrientation();
     if (Orientation.HORIZONTAL.equals(splitOrientation)) {
       splitOrientation = Orientation.VERTICAL;
     } else {
@@ -403,12 +405,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   }
 
   private void setOrientation(Orientation orientation, boolean fromClient) {
-    splitOrientation = orientation;
-    if (currentLayout != null) {
-      currentLayout.setOrientation(orientation);
-      currentLayout.showSourceCode();
+    if (currentLayout != null && orientation != getOrientation()) {
+        currentLayout.setOrientation(orientation);
+        currentLayout.setSourceCollapsed(false);
+        fireOrientationChangedEvent(orientation, fromClient);
     }
-    fireOrientationChangedEvent(orientation, fromClient);
   }
 
   /**
@@ -534,11 +535,10 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private void adjustSplitOrientation(boolean portraitOrientation) {
     if (portraitOrientation) {
-      splitOrientation = Orientation.VERTICAL;
+      setOrientation(Orientation.VERTICAL);
     } else {
-      splitOrientation = Orientation.HORIZONTAL;
+      setOrientation(Orientation.HORIZONTAL);
     }
-    setOrientation(splitOrientation);
   }
 
   /**

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.Version;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -480,7 +481,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
         e.style.colorScheme = $0;
         """;
 
-    element.executeJs(script, theme);
+    element.executeJs(script, new Serializable[] {theme});
 
     collectThemeChangeObservers(component).forEach(observer -> observer.onThemeChange(theme));
     observeThemeChange(component);

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -77,9 +77,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private EnhancedRouteTabs tabs;
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
-  private Checkbox orientationCB;
-  private Checkbox codeCB;
-  private Checkbox codePositionCB;
   private Checkbox themeCB;
   private Orientation splitOrientation;
   private Button helperButton;
@@ -93,28 +90,14 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
     tabs = new EnhancedRouteTabs();
 
-    // Footer
-    orientationCB = new Checkbox("Toggle Orientation");
-    orientationCB.setValue(true);
-    orientationCB.addClassName("smallcheckbox");
-    orientationCB.addValueChangeListener(ev -> {
-      if (ev.isFromClient()) {
-        toggleSplitterOrientation(ev.isFromClient());
-      }
-    });
-    codeCB = new Checkbox("Show Source Code");
-    codeCB.setValue(true);
-    codeCB.addClassName("smallcheckbox");
-    codeCB.addValueChangeListener(
-        ev -> fireSourceCollapseChangedEvent(!ev.getValue(), ev.isFromClient()));
+    // The source controls live inside SourceCodeViewer and signal across components
+    // via bubbling DOM events; collapse carries data, so it uses SourceCollapseChangedEvent.
     addSourceCollapseListener(ev -> {
       sourceCollapsed = ev.isCollapsed();
       updateSplitterPosition();
     });
-    codePositionCB = new Checkbox("Toggle Code Position");
-    codePositionCB.setValue(true);
-    codePositionCB.addClassName("smallcheckbox");
-    codePositionCB.addValueChangeListener(ev -> toggleSourcePosition(ev.isFromClient()));
+    getElement().addEventListener("source-flip", ev -> toggleSourcePosition(true));
+    getElement().addEventListener("source-rotate", ev -> toggleSplitterOrientation(true));
     themeCB = new Checkbox("Dark Theme");
     themeCB.setValue(false);
     themeCB.addClassName("smallcheckbox");
@@ -126,7 +109,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     footer = new HorizontalLayout();
     footer.setWidthFull();
     footer.setJustifyContentMode(JustifyContentMode.END);
-    footer.add(codeCB, codePositionCB, orientationCB, themeCB);
+    footer.add(themeCB);
     footer.setClassName("demo-footer");
 
     Package pkg = this.getClass().getPackage();
@@ -348,8 +331,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
       } else {
         currentLayout.showSourceCode();
       }
-      orientationCB.setEnabled(!sourceCollapsed);
-      codePositionCB.setEnabled(!sourceCollapsed);
     }
   }
 
@@ -359,8 +340,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
    * @param visible {@code true} to make the source code visible, {@code false} otherwise
    */
   public void setSourceVisible(boolean visible) {
-    codeCB.setValue(visible);
-    codePositionCB.setVisible(visible);
+    fireSourceCollapseChangedEvent(!visible, false);
   }
 
   /**
@@ -428,7 +408,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
       currentLayout.setOrientation(orientation);
       currentLayout.setSplitterPosition(50);
     }
-    orientationCB.setValue(Orientation.HORIZONTAL.equals(orientation));
     fireOrientationChangedEvent(orientation, fromClient);
   }
 
@@ -525,9 +504,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private void updateFooterButtonsVisibility() {
     boolean hasSourceCode = currentLayout != null;
     ComponentUtil.fireEvent(this, new TabbedDemoSourceEvent(this, hasSourceCode));
-    orientationCB.setVisible(hasSourceCode);
-    codeCB.setVisible(hasSourceCode);
-    codePositionCB.setVisible(hasSourceCode);
   }
 
   /**
@@ -546,8 +522,10 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     super.onAttach(attachEvent);
     getUI().ifPresent(ui -> ui.getPage().retrieveExtendedClientDetails(receiver -> {
       boolean mobile = receiver.getBodyClientWidth() <= MOBILE_DEVICE_BREAKPOINT_WIDTH;
-      codeCB.setValue(!sourceCollapsed && !mobile);
-      codePositionCB.setValue(!sourceCollapsed && !mobile);
+      boolean shouldCollapse = sourceCollapsed || mobile;
+      if (shouldCollapse != sourceCollapsed) {
+        fireSourceCollapseChangedEvent(shouldCollapse, false);
+      }
 
       boolean portraitOrientation = receiver.getBodyClientHeight() > receiver.getBodyClientWidth();
       adjustSplitOrientation(portraitOrientation);

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -79,6 +79,10 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
   private Checkbox themeCB;
+  // The desired split orientation. Mirrors the current layout's orientation when one exists, and
+  // outlives it while no layout is present, so a device-driven adjustment (e.g. portrait -> VERTICAL
+  // made on a source-less demo) is carried over to the next source-bearing demo.
+  private Orientation splitOrientation = Orientation.HORIZONTAL;
   private Button helperButton;
   private DemoHelperViewer demoHelperViewer;
 
@@ -223,10 +227,8 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
       createSourceCodeTab(demo.getClass(), demoSource).ifPresent(sourceTabs::add);
     }
 
-    Orientation splitOrientation = null;
     SourcePosition previousPosition = null;
     if (currentLayout != null) {
-      splitOrientation = currentLayout.getOrientation();
       previousPosition = currentLayout.getSourcePosition();
     }
 
@@ -247,10 +249,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
         currentLayout.setSourcePosition(resolveDefaultPosition(previousPosition));
       }
 
-      if (splitOrientation != null) {
-        setOrientation(splitOrientation);
-        updateSplitterPosition();
-      }
+      // A freshly created layout defaults to HORIZONTAL; adopt the orientation remembered across
+      // demos (which may have changed while no layout was present). This is initialization, not a
+      // state change, so it does not fire an OrientationChangedEvent.
+      currentLayout.setOrientation(splitOrientation);
+      updateSplitterPosition();
 
       setupDemoHelperButton(currentLayout.getContent().getPrimaryComponent().getClass());
     } else {
@@ -421,7 +424,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
    * @return the current orientation
    */
   public Orientation getOrientation() {
-    return currentLayout.getOrientation();
+    return splitOrientation;
   }
 
   /**
@@ -434,11 +437,15 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   }
 
   private void setOrientation(Orientation orientation, boolean fromClient) {
-    if (currentLayout != null && orientation != getOrientation()) {
-        currentLayout.setOrientation(orientation);
-        updateSplitterPosition();
-        fireOrientationChangedEvent(orientation, fromClient);
+    if (orientation == splitOrientation) {
+      return;
     }
+    splitOrientation = orientation;
+    if (currentLayout != null) {
+      currentLayout.setOrientation(orientation);
+      updateSplitterPosition();
+    }
+    fireOrientationChangedEvent(orientation, fromClient);
   }
 
   /**

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -378,6 +378,9 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private void setSourcePosition(SourcePosition sourcePosition, boolean fromClient) {
     if (currentLayout != null) {
       currentLayout.setSourcePosition(sourcePosition);
+      if (sourceCollapsed) {
+        updateSplitterPosition();
+      }
       SourcePosition resolvedPosition = sourcePosition == SourcePosition.DEFAULT
           ? resolveDefaultPosition(currentLayout.getSourcePosition())
           : sourcePosition;

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -21,6 +21,7 @@ package com.flowingcode.vaadin.addons.demo;
 
 import com.flowingcode.vaadin.addons.GithubBranch;
 import com.flowingcode.vaadin.addons.demo.events.SourceCollapseChangedEvent;
+import com.flowingcode.vaadin.addons.demo.events.SourcePositionChangedEvent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -112,7 +113,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     codePositionCB = new Checkbox("Toggle Code Position");
     codePositionCB.setValue(true);
     codePositionCB.addClassName("smallcheckbox");
-    codePositionCB.addValueChangeListener(ev -> toggleSourcePosition());
+    codePositionCB.addValueChangeListener(ev -> toggleSourcePosition(ev.isFromClient()));
     themeCB = new Checkbox("Dark Theme");
     themeCB.setValue(false);
     themeCB.addClassName("smallcheckbox");
@@ -365,8 +366,28 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
    * Toggles the position of the source code relative to the demo content.
    */
   public void toggleSourcePosition() {
+    toggleSourcePosition(false);
+  }
+
+  private void toggleSourcePosition(boolean fromClient) {
     if (currentLayout != null) {
-      currentLayout.toggleSourcePosition();
+      setSourcePosition(currentLayout.getSourcePosition().toggle(), fromClient);
+    }
+  }
+
+  /**
+   * Sets the position of the source code relative to the demo content.
+   *
+   * @param sourcePosition the new source position
+   */
+  public void setSourcePosition(SourcePosition sourcePosition) {
+    setSourcePosition(sourcePosition, false);
+  }
+
+  private void setSourcePosition(SourcePosition sourcePosition, boolean fromClient) {
+    if (currentLayout != null) {
+      currentLayout.setSourcePosition(sourcePosition);
+      fireSourcePositionChangedEvent(sourcePosition, fromClient);
     }
   }
 
@@ -574,8 +595,22 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     ComponentUtil.addListener(this, SourceCollapseChangedEvent.class, listener);
   }
 
+  /**
+   * Adds a listener for {@link SourcePositionChangedEvent}.
+   *
+   * @param listener the listener to add
+   */
+  public void addSourcePositionChangedListener(
+      ComponentEventListener<SourcePositionChangedEvent> listener) {
+    ComponentUtil.addListener(this, SourcePositionChangedEvent.class, listener);
+  }
+
   private void fireSourceCollapseChangedEvent(boolean collapsed, boolean fromClient) {
     fireEvent(new SourceCollapseChangedEvent(this, fromClient, collapsed));
+  }
+
+  private void fireSourcePositionChangedEvent(SourcePosition sourcePosition, boolean fromClient) {
+    fireEvent(new SourcePositionChangedEvent(this, fromClient, sourcePosition));
   }
 
 }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -78,6 +78,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
   private Checkbox themeCB;
+  private Orientation splitOrientation;
   private Button helperButton;
   private DemoHelperViewer demoHelperViewer;
 
@@ -220,11 +221,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     List<SourceCodeTab> sourceTabs = new ArrayList<>(demoSources.length);
     for (DemoSource demoSource : demoSources) {
       createSourceCodeTab(demo.getClass(), demoSource).ifPresent(sourceTabs::add);
-    }
-
-    Orientation splitOrientation = null;
-    if (currentLayout != null) {
-      splitOrientation = currentLayout.getOrientation();
     }
 
     if (!sourceTabs.isEmpty()) {
@@ -380,8 +376,6 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     if (currentLayout == null) {
       return;
     }
-
-    Orientation splitOrientation = getOrientation();
     if (Orientation.HORIZONTAL.equals(splitOrientation)) {
       splitOrientation = Orientation.VERTICAL;
     } else {
@@ -409,11 +403,12 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   }
 
   private void setOrientation(Orientation orientation, boolean fromClient) {
-    if (currentLayout != null && orientation != getOrientation()) {
-        currentLayout.setOrientation(orientation);
-        currentLayout.showSourceCode();
-        fireOrientationChangedEvent(orientation, fromClient);
+    splitOrientation = orientation;
+    if (currentLayout != null) {
+      currentLayout.setOrientation(orientation);
+      currentLayout.showSourceCode();
     }
+    fireOrientationChangedEvent(orientation, fromClient);
   }
 
   /**
@@ -539,10 +534,11 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private void adjustSplitOrientation(boolean portraitOrientation) {
     if (portraitOrientation) {
-      setOrientation(Orientation.VERTICAL);
+      splitOrientation = Orientation.VERTICAL;
     } else {
-      setOrientation(Orientation.HORIZONTAL);
+      splitOrientation = Orientation.HORIZONTAL;
     }
+    setOrientation(splitOrientation);
   }
 
   /**

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -20,6 +20,7 @@
 package com.flowingcode.vaadin.addons.demo;
 
 import com.flowingcode.vaadin.addons.GithubBranch;
+import com.flowingcode.vaadin.addons.demo.events.SourceCollapseChangedEvent;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -70,6 +71,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private static final int MOBILE_DEVICE_BREAKPOINT_WIDTH = 768;
   private boolean autoVisibility;
+  private boolean sourceCollapsed;
   private EnhancedRouteTabs tabs;
   private HorizontalLayout footer;
   private SplitLayoutDemo currentLayout;
@@ -101,7 +103,12 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     codeCB = new Checkbox("Show Source Code");
     codeCB.setValue(true);
     codeCB.addClassName("smallcheckbox");
-    codeCB.addValueChangeListener(ev -> updateSplitterPosition());
+    codeCB.addValueChangeListener(
+        ev -> fireSourceCollapseChangedEvent(!ev.getValue(), ev.isFromClient()));
+    addSourceCollapseListener(ev -> {
+      sourceCollapsed = ev.isCollapsed();
+      updateSplitterPosition();
+    });
     codePositionCB = new Checkbox("Toggle Code Position");
     codePositionCB.setValue(true);
     codePositionCB.addClassName("smallcheckbox");
@@ -334,13 +341,13 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
   private void updateSplitterPosition() {
     if (currentLayout != null) {
-      if (codeCB.getValue()) {
-        currentLayout.showSourceCode();
-      } else {
+      if (sourceCollapsed) {
         currentLayout.hideSourceCode();
+      } else {
+        currentLayout.showSourceCode();
       }
-      orientationCB.setEnabled(codeCB.getValue());
-      codePositionCB.setEnabled(codeCB.getValue());
+      orientationCB.setEnabled(!sourceCollapsed);
+      codePositionCB.setEnabled(!sourceCollapsed);
     }
   }
 
@@ -512,8 +519,8 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     super.onAttach(attachEvent);
     getUI().ifPresent(ui -> ui.getPage().retrieveExtendedClientDetails(receiver -> {
       boolean mobile = receiver.getBodyClientWidth() <= MOBILE_DEVICE_BREAKPOINT_WIDTH;
-      codeCB.setValue(codeCB.getValue() && !mobile);
-      codePositionCB.setValue(codeCB.getValue() && !mobile);
+      codeCB.setValue(!sourceCollapsed && !mobile);
+      codePositionCB.setValue(!sourceCollapsed && !mobile);
 
       boolean portraitOrientation = receiver.getBodyClientHeight() > receiver.getBodyClientWidth();
       adjustSplitOrientation(portraitOrientation);
@@ -555,6 +562,20 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
         logger.error("Error creating an instance", e);
       }
     }
+  }
+
+  /**
+   * Adds a listener for {@link SourceCollapseChangedEvent}.
+   *
+   * @param listener the listener to add
+   */
+  public void addSourceCollapseListener(
+      ComponentEventListener<SourceCollapseChangedEvent> listener) {
+    ComponentUtil.addListener(this, SourceCollapseChangedEvent.class, listener);
+  }
+
+  private void fireSourceCollapseChangedEvent(boolean collapsed, boolean fromClient) {
+    fireEvent(new SourceCollapseChangedEvent(this, fromClient, collapsed));
   }
 
 }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -224,8 +224,10 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     }
 
     Orientation splitOrientation = null;
+    SourcePosition previousPosition = null;
     if (currentLayout != null) {
       splitOrientation = currentLayout.getOrientation();
+      previousPosition = currentLayout.getSourcePosition();
     }
 
     if (!sourceTabs.isEmpty()) {
@@ -238,6 +240,13 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
 
     if (currentLayout != null) {
       content = currentLayout;
+
+      // A DEFAULT position is soft: it adopts the position carried over from the previously shown
+      // demo (SECONDARY if there is none). An explicit PRIMARY/SECONDARY always wins.
+      if (currentLayout.getSourcePosition() == SourcePosition.DEFAULT) {
+        currentLayout.setSourcePosition(resolveDefaultPosition(previousPosition));
+      }
+
       if (splitOrientation != null) {
         setOrientation(splitOrientation);
         updateSplitterPosition();
@@ -369,8 +378,24 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private void setSourcePosition(SourcePosition sourcePosition, boolean fromClient) {
     if (currentLayout != null) {
       currentLayout.setSourcePosition(sourcePosition);
-      fireSourcePositionChangedEvent(sourcePosition, fromClient);
+      SourcePosition resolvedPosition = sourcePosition == SourcePosition.DEFAULT
+          ? resolveDefaultPosition(currentLayout.getSourcePosition())
+          : sourcePosition;
+      fireSourcePositionChangedEvent(resolvedPosition, fromClient);
     }
+  }
+
+  /**
+   * Resolves a {@link SourcePosition#DEFAULT} position against the position carried over from the
+   * previously shown demo.
+   *
+   * @param previous the carried-over position, or {@code null} if there is none
+   * @return {@code previous} when it is a concrete position, otherwise {@link SourcePosition#SECONDARY}
+   */
+  private static SourcePosition resolveDefaultPosition(SourcePosition previous) {
+    return (previous == null || previous == SourcePosition.DEFAULT)
+        ? SourcePosition.SECONDARY
+        : previous;
   }
 
   private void toggleSplitterOrientation(boolean fromClient) {

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -20,6 +20,7 @@
 package com.flowingcode.vaadin.addons.demo;
 
 import com.flowingcode.vaadin.addons.GithubBranch;
+import com.flowingcode.vaadin.addons.demo.events.OrientationChangedEvent;
 import com.flowingcode.vaadin.addons.demo.events.SourceCollapseChangedEvent;
 import com.flowingcode.vaadin.addons.demo.events.SourcePositionChangedEvent;
 import com.vaadin.flow.component.AttachEvent;
@@ -98,7 +99,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     orientationCB.addClassName("smallcheckbox");
     orientationCB.addValueChangeListener(ev -> {
       if (ev.isFromClient()) {
-        toggleSplitterOrientation();
+        toggleSplitterOrientation(ev.isFromClient());
       }
     });
     codeCB = new Checkbox("Show Source Code");
@@ -391,7 +392,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     }
   }
 
-  private void toggleSplitterOrientation() {
+  private void toggleSplitterOrientation(boolean fromClient) {
     if (currentLayout == null) {
       return;
     }
@@ -400,7 +401,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     } else {
       splitOrientation = Orientation.HORIZONTAL;
     }
-    setOrientation(splitOrientation);
+    setOrientation(splitOrientation, fromClient);
   }
 
   /**
@@ -418,12 +419,17 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
    * @param orientation the new orientation
    */
   public void setOrientation(Orientation orientation) {
+    setOrientation(orientation, false);
+  }
+
+  private void setOrientation(Orientation orientation, boolean fromClient) {
     splitOrientation = orientation;
     if (currentLayout != null) {
       currentLayout.setOrientation(orientation);
       currentLayout.setSplitterPosition(50);
     }
     orientationCB.setValue(Orientation.HORIZONTAL.equals(orientation));
+    fireOrientationChangedEvent(orientation, fromClient);
   }
 
   /**
@@ -605,12 +611,26 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
     ComponentUtil.addListener(this, SourcePositionChangedEvent.class, listener);
   }
 
+  /**
+   * Adds a listener for {@link OrientationChangedEvent}.
+   *
+   * @param listener the listener to add
+   */
+  public void addOrientationChangedListener(
+      ComponentEventListener<OrientationChangedEvent> listener) {
+    ComponentUtil.addListener(this, OrientationChangedEvent.class, listener);
+  }
+
   private void fireSourceCollapseChangedEvent(boolean collapsed, boolean fromClient) {
     fireEvent(new SourceCollapseChangedEvent(this, fromClient, collapsed));
   }
 
   private void fireSourcePositionChangedEvent(SourcePosition sourcePosition, boolean fromClient) {
     fireEvent(new SourcePositionChangedEvent(this, fromClient, sourcePosition));
+  }
+
+  private void fireOrientationChangedEvent(Orientation orientation, boolean fromClient) {
+    fireEvent(new OrientationChangedEvent(this, fromClient, orientation));
   }
 
 }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/TabbedDemo.java
@@ -436,7 +436,7 @@ public class TabbedDemo extends VerticalLayout implements RouterLayout {
   private void setOrientation(Orientation orientation, boolean fromClient) {
     if (currentLayout != null && orientation != getOrientation()) {
         currentLayout.setOrientation(orientation);
-        currentLayout.setSourceCollapsed(false);
+        updateSplitterPosition();
         fireOrientationChangedEvent(orientation, fromClient);
     }
   }

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/OrientationChangedEvent.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/OrientationChangedEvent.java
@@ -1,0 +1,38 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.events;
+
+import com.flowingcode.vaadin.addons.demo.TabbedDemo;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+import lombok.Getter;
+
+@SuppressWarnings("serial")
+public class OrientationChangedEvent extends ComponentEvent<TabbedDemo> {
+
+  @Getter
+  private Orientation orientation;
+
+  public OrientationChangedEvent(TabbedDemo source, boolean fromClient, Orientation orientation) {
+    super(source, fromClient);
+    this.orientation = orientation;
+  }
+
+}

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/SourceCollapseChangedEvent.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/SourceCollapseChangedEvent.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.events;
+
+import com.flowingcode.vaadin.addons.demo.TabbedDemo;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import lombok.Getter;
+
+@SuppressWarnings("serial")
+@DomEvent("source-collapse-changed")
+public class SourceCollapseChangedEvent extends ComponentEvent<TabbedDemo> {
+
+  @Getter
+  private boolean collapsed;
+
+  public SourceCollapseChangedEvent(TabbedDemo source, boolean fromClient,
+      @EventData("event.detail.collapsed") boolean collapsed) {
+    super(source, fromClient);
+    this.collapsed = collapsed;
+  }
+
+}

--- a/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/SourcePositionChangedEvent.java
+++ b/base/src/main/java/com/flowingcode/vaadin/addons/demo/events/SourcePositionChangedEvent.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.events;
+
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
+import com.flowingcode.vaadin.addons.demo.TabbedDemo;
+import com.vaadin.flow.component.ComponentEvent;
+import lombok.Getter;
+
+@SuppressWarnings("serial")
+public class SourcePositionChangedEvent extends ComponentEvent<TabbedDemo> {
+
+  @Getter
+  private SourcePosition sourcePosition;
+
+  public SourcePositionChangedEvent(TabbedDemo source, boolean fromClient,
+      SourcePosition sourcePosition) {
+    super(source, fromClient);
+    this.sourcePosition = sourcePosition;
+  }
+
+}

--- a/base/src/main/resources/META-INF/VAADIN/package.properties
+++ b/base/src/main/resources/META-INF/VAADIN/package.properties
@@ -1,1 +1,20 @@
+###
+# #%L
+# Commons Demo
+# %%
+# Copyright (C) 2020 - 2026 Flowing Code
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 vaadin.allowed-packages=com.flowingcode

--- a/base/src/main/resources/META-INF/resources/frontend/commons-demo-iconset.ts
+++ b/base/src/main/resources/META-INF/resources/frontend/commons-demo-iconset.ts
@@ -63,6 +63,19 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. 
 
+---
+
+Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com
+License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+Copyright 2024 Fonticons, Inc.
+
+---
+
+All brand icons are trademarks of their respective owners. The use of these
+trademarks does not indicate endorsement of the trademark holder by Font
+Awesome, nor vice versa. **Please do not use brand logos for any purpose except
+to represent the company, product, or service to which they refer.**
+
 */
 
 registerStyles(
@@ -94,6 +107,14 @@ template.innerHTML = `
       <g id="hide-source">
         <!-- lucide panel-left-open-->
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/></svg>
+      </g>
+      <g id="home">
+        <!-- fas:home -->
+        <svg viewBox="0 0 576 512"><path d="M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/></svg>
+      </g>
+      <g id="github">
+        <!-- fab:github -->
+        <svg viewBox="0 0 512 512"><path xmlns="http://www.w3.org/2000/svg" fill="currentColor" d="M173.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM252.8 8c-138.7 0-244.8 105.3-244.8 244 0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1 100-33.2 167.8-128.1 167.8-239 0-138.7-112.5-244-251.2-244zM105.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9s4.3 3.3 5.6 2.3c1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
       </g>
     </defs>
 </svg>`;

--- a/base/src/main/resources/META-INF/resources/frontend/commons-demo-iconset.ts
+++ b/base/src/main/resources/META-INF/resources/frontend/commons-demo-iconset.ts
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+import '@vaadin/icon/vaadin-icon.js';
+import { Iconset } from '@vaadin/icon/vaadin-iconset.js';
+import { css, registerStyles } from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
+
+/**
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2023 as part of Feather (MIT).
+All other copyright (c) for Lucide are held by Lucide Contributors 2025.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The MIT License (MIT) (for portions derived from Feather)
+
+Copyright (c) 2013-2023 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 
+
+*/
+
+registerStyles(
+  'vaadin-button',
+  css`
+    [part] ::slotted(vaadin-icon[icon^='commons-demo:']), [part] ::slotted(iron-icon[icon^='commons-demo:']) 
+    {
+      padding: 0.25em;
+      box-sizing: border-box !important;
+    }`,
+);
+
+const template = document.createElement('template');
+template.innerHTML = `
+<svg xmlns:svg="http://www.w3.org/2000/svg">
+   <defs>
+      <g id="rotate">
+        <!-- lucide rotate-cw-square -->
+      	<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-rotate-cw-square-icon lucide-rotate-cw-square"><path d="M12 5H6a2 2 0 0 0-2 2v3"/><path d="m9 8 3-3-3-3"/><path d="M4 14v4a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/></svg>
+      </g>
+      <g id="flip">
+        <!-- lucide move-horizontal -->
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 8 4 4-4 4"/><path d="M2 12h20"/><path d="m6 8-4 4 4 4"/></svg>
+      </g>
+      <g id="show-source">
+        <!-- lucide panel-left-close -->
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m16 15-3-3 3-3"/></svg>
+      </g>
+      <g id="hide-source">
+        <!-- lucide panel-left-open-->
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 3v18"/><path d="m14 9 3 3-3 3"/></svg>
+      </g>
+    </defs>
+</svg>`;
+
+customElements.whenDefined('vaadin-iconset').then(Iconset=>{
+  Iconset.register('commons-demo', 24, template);
+});

--- a/base/src/main/resources/META-INF/resources/frontend/source-code-viewer-buttons.ts
+++ b/base/src/main/resources/META-INF/resources/frontend/source-code-viewer-buttons.ts
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+import {html, LitElement} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import '@vaadin/button/vaadin-button.js';
+import './commons-demo-iconset.js';
+
+/**
+ * Overlay controls pinned over the source code. Each button dispatches a bubbling DOM event that is
+ * handled by an enclosing layout (see TabbedDemo), which is what actually collapses, repositions or
+ * reorients the source panel. Firing the events on the client avoids a server roundtrip on click.
+ */
+@customElement("source-code-viewer-buttons")
+export class SourceCodeViewerButtons extends LitElement {
+
+  // Render in light DOM so the shared stylesheet (shared-styles.css) styles the buttons.
+  createRenderRoot() {
+    return this;
+  }
+
+  private fire(type: string, detail?: any) {
+    this.dispatchEvent(new CustomEvent(type, {bubbles: true, detail}));
+  }
+
+  render() {
+    return html`
+      <vaadin-button theme="icon tertiary-inline" aria-label="Show source code"
+          class="source-code-viewer-button source-code-viewer-show-button"
+          @click=${() => this.fire('source-collapse-changed', {collapsed: false})}>
+        <vaadin-icon icon="commons-demo:show-source"></vaadin-icon>
+      </vaadin-button>
+      <vaadin-button theme="icon tertiary-inline" aria-label="Hide source code"
+          class="source-code-viewer-button source-code-viewer-hide-button"
+          @click=${() => this.fire('source-collapse-changed', {collapsed: true})}>
+        <vaadin-icon icon="commons-demo:hide-source"></vaadin-icon>
+      </vaadin-button>
+      <vaadin-button theme="icon tertiary-inline" aria-label="Flip source code"
+          class="source-code-viewer-button source-code-viewer-flip-button"
+          @click=${() => this.fire('source-flip')}>
+        <vaadin-icon icon="commons-demo:flip"></vaadin-icon>
+      </vaadin-button>
+      <vaadin-button theme="icon tertiary-inline" aria-label="Rotate source code"
+          class="source-code-viewer-button source-code-viewer-rotate-button"
+          @click=${() => this.fire('source-rotate')}>
+        <vaadin-icon icon="commons-demo:rotate"></vaadin-icon>
+      </vaadin-button>
+    `;
+  }
+}

--- a/base/src/main/resources/META-INF/resources/frontend/styles/commons-demo/shared-styles.css
+++ b/base/src/main/resources/META-INF/resources/frontend/styles/commons-demo/shared-styles.css
@@ -51,5 +51,122 @@ code-highlighter code {
 	cursor: pointer;
 }
 
+.source-code-viewer {
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	overflow: hidden;
+}
+
+.source-code-viewer-codeviewer-wrapper {
+	display: flex;
+	flex-grow: 1;
+	overflow: auto;
+}
+
+.source-code-viewer-codeviewer-wrapper > code-viewer {
+	flex-grow: 1;
+}
+
+.source-code-viewer-buttons-wrapper {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+}
+
+source-code-viewer-buttons {
+	position: absolute;
+	z-index: 1;
+	right: calc(0.25rem + var(--code-viewer-gutter, 0px));
+	top: 0.25rem;
+	display: flex;
+	gap: var(--lumo-space-xs, 0.25rem);
+	container-type: inline-size;
+	width: 100%;
+	justify-content: end;
+	pointer-events: none;
+}
+
+vaadin-button.source-code-viewer-button {
+	color: color-mix(in srgb, #f8f8f2 70%, transparent);
+	pointer-events: auto;
+	background: transparent;
+	display: none;
+	padding: 0;
+}
+
+vaadin-button.source-code-viewer-button vaadin-icon {
+    --vaadin-icon-size: 20px;
+    padding: 0.125em;
+}
+
+@container style(--lumo-size-m) {
+  vaadin-button.source-code-viewer-button vaadin-icon {
+    padding: 0.25em;
+  }
+}
+
+
+vaadin-button.source-code-viewer-show-button {
+	display: var(--source-code-viewer-show-button-display, none);
+	color: var(--lumo-body-text-color, var(--vaadin-text-color));
+	position: fixed;
+}
+
+[orientation="horizontal"] [slot="primary"] vaadin-button.source-code-viewer-show-button {
+	right: 0;
+}
+
+[orientation="horizontal"] [slot="secondary"] vaadin-button.source-code-viewer-show-button {
+	right: 0.5rem;
+}
+
+[orientation="vertical"] [slot="primary"] vaadin-button.source-code-viewer-show-button {
+	top: 0.5rem;
+}
+
+[orientation="vertical"] [slot="secondary"] vaadin-button.source-code-viewer-show-button {
+	top: 0;
+}
+
+/* Rotate the icons to match the layout disposition. */
+[orientation="horizontal"] [slot="secondary"] vaadin-button.source-code-viewer-button{
+	transform: rotate(0deg);
+	&.source-code-viewer-rotate-button { transform: scaleX(-1) rotate(90deg); }
+}
+
+[orientation="horizontal"] [slot="primary"] vaadin-button.source-code-viewer-button {
+	transform: rotate(180deg);
+	&.source-code-viewer-rotate-button { transform: rotate(0deg); }	
+}
+
+[orientation="vertical"] [slot="secondary"] vaadin-button.source-code-viewer-button {
+	transform: rotate(90deg);
+	&.source-code-viewer-rotate-button { transform: rotate(0deg); }
+}
+
+[orientation="vertical"] [slot="primary"] vaadin-button.source-code-viewer-button {
+	transform: rotate(270deg);
+	&.source-code-viewer-rotate-button { transform: scaleX(-1) rotate(90deg); }
+}
+
+@container (min-width: 82px) {
+	vaadin-button.source-code-viewer-flip-button {
+		display: block;
+	}
+}
+
+@container (min-width: 53px) {
+	vaadin-button.source-code-viewer-rotate-button {
+		display: block;
+	}
+}
+
+@container (min-width: 24px) {
+	vaadin-button.source-code-viewer-hide-button {
+		display: block;
+	}
+}
+
 .commons-demo-split-layout { overflow: hidden }
 .commons-demo-split-layout > [slot] { overflow: auto; }

--- a/base/src/main/resources/META-INF/resources/frontend/styles/commons-demo/vaadin-select-overlay.css
+++ b/base/src/main/resources/META-INF/resources/frontend/styles/commons-demo/vaadin-select-overlay.css
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /** Needed in order to prevent vaadin-select from remaining 'closing' when switching from Lumo to Aura/Base*/
 :host([theme~='demo-footer-theme-select']) vaadin-select-overlay {
 	animation-name: none;

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/AppShellConfiguratorImpl.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/AppShellConfiguratorImpl.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.flowingcode.vaadin.addons.demo;
 
 import com.vaadin.flow.component.page.AppShellConfigurator;

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayCallables.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayCallables.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.it;
+
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
+import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
+import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+
+/**
+ * testbench-rpc callable contract used by the level-E integration tests to read the server-side
+ * state coordinated by {@code TabbedDemo} directly from the browser test, instead of scraping DOM
+ * status elements. Implemented (with {@code @ClientCallable}) by {@link OverlayView}.
+ */
+public interface OverlayCallables extends RmiCallable {
+
+  /** Current split orientation, {@code HORIZONTAL} or {@code VERTICAL}. */
+  Orientation orientation();
+
+  /** Whether the source panel is currently collapsed (latest collapse event). */
+  boolean sourceCollapsed();
+
+  /** Latest source position, {@code PRIMARY} or {@code SECONDARY} (null before any change). */
+  SourcePosition sourcePosition();
+
+  /** {@code isFromClient()} of the most recent {@code SourceCollapseChangedEvent}. */
+  boolean lastCollapseFromClient();
+
+  /** {@code isFromClient()} of the most recent {@code SourcePositionChangedEvent}. */
+  boolean lastPositionFromClient();
+
+  /** {@code isFromClient()} of the most recent {@code OrientationChangedEvent}. */
+  boolean lastOrientationFromClient();
+
+}

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayControlsIT.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayControlsIT.java
@@ -1,0 +1,189 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.it;
+
+import static com.vaadin.flow.component.splitlayout.SplitLayout.Orientation.HORIZONTAL;
+import static com.vaadin.flow.component.splitlayout.SplitLayout.Orientation.VERTICAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Integration tests for the source-code viewer overlay controls. Each test clicks a rendered
+ * overlay button and then asserts the effect on both the DOM (CSS-driven visibility, slot
+ * placement, orientation attribute) and the server-side state, the latter read over testbench-rpc
+ * through {@link OverlayCallables} — see {@link OverlayView} for the {@code @ClientCallable}
+ * implementation.
+ *
+ * <p>
+ * The unit ({@code SplitLayoutDemoTest}) and UI-unit ({@code TabbedDemoUIUnitTest}) layers cover
+ * the mechanics and the programmatic ({@code fromClient=false}) paths; these tests add what only a
+ * real browser can show: CSS visibility, real geometry, and the genuine {@code fromClient=true}
+ * origin of a rendered button click.
+ */
+public class OverlayControlsIT extends AbstractViewTest implements HasRpcSupport {
+
+  private final OverlayCallables $server = createCallableProxy(OverlayCallables.class);
+
+  public OverlayControlsIT() {
+    super(null);
+  }
+
+  /** Landscape viewport (deterministic HORIZONTAL, non-collapsed baseline) + navigate. */
+  private void open() {
+    getDriver().manage().window().setSize(new Dimension(1200, 800));
+    getDriver().get(getURL("it/rpc-overlay"));
+    getCommandExecutor().waitForVaadin();
+    getDriver().findElement(By.id("content"));
+    waitUntil(d -> hasElement("vaadin-button.source-code-viewer-hide-button"));
+  }
+
+  private WebElement button(String name) {
+    return getDriver()
+        .findElement(By.cssSelector("vaadin-button.source-code-viewer-" + name + "-button"));
+  }
+
+  private void click(String name) {
+    button(name).click();
+    getCommandExecutor().waitForVaadin();
+  }
+
+  private boolean hasElement(String cssSelector) {
+    return !getDriver().findElements(By.cssSelector(cssSelector)).isEmpty();
+  }
+
+  private String orientationAttribute() {
+    return getDriver().findElement(By.cssSelector("vaadin-split-layout")).getAttribute("orientation");
+  }
+
+  /** Rendered pixel width of the source panel (the slotted {@code code-viewer}). */
+  private int sourcePanelWidth() {
+    // the slot that contains the source-code-viewer
+    String xpath = "//vaadin-split-layout/*[div[contains(@class, 'source-code-viewer')]]";
+    return getDriver().findElement(By.xpath(xpath)).getSize().getWidth();
+  }
+
+  /** Rendered pixel width of the whole split layout. */
+  private int splitLayoutWidth() {
+    return getDriver().findElement(By.cssSelector("vaadin-split-layout")).getSize().getWidth();
+  }
+
+  /** IT-BTN-01 — the action buttons are visible, the show button hidden, at a normal split. */
+  @Test
+  public void overlayButtonsVisibility() {
+    open();
+    assertTrue(button("hide").isDisplayed());
+    assertTrue(button("flip").isDisplayed());
+    assertTrue(button("rotate").isDisplayed());
+    assertFalse(button("show").isDisplayed());
+  }
+
+  /** IT-COL-01 — clicking Hide collapses the panel, reveals Show, and is client-originated. */
+  @Test
+  public void clickingHideCollapsesAndRevealsShow() {
+    open();
+    assertFalse($server.sourceCollapsed());
+
+    click("hide");
+
+    assertTrue($server.sourceCollapsed());
+    assertTrue($server.lastCollapseFromClient());
+    waitUntil(d -> button("show").isDisplayed());
+    // real geometry: the collapsed source panel measures ~0px wide
+    waitUntil(d -> sourcePanelWidth() < 5);
+    assertTrue("collapsed source panel should measure ~0px but was " + sourcePanelWidth(),
+        sourcePanelWidth() < 5);
+  }
+
+  /** IT-COL-02 — clicking Show restores the panel. */
+  @Test
+  public void clickingShowRestoresPanel() {
+    open();
+    click("hide");
+    waitUntil(d -> button("show").isDisplayed());
+
+    click("show");
+
+    assertFalse($server.sourceCollapsed());
+    waitUntil(d -> button("hide").isDisplayed());
+    assertFalse(button("show").isDisplayed());
+    // real geometry: the splitter returns to ~50, so the source panel spans ~half the layout
+    waitUntil(d -> {
+      int total = splitLayoutWidth();
+      return total > 0 && Math.abs(sourcePanelWidth() - total / 2.0) < total * 0.1;
+    });
+    double ratio = (double) sourcePanelWidth() / splitLayoutWidth();
+    assertTrue("restored source panel should span ~50% of the layout but was " + ratio,
+        ratio > 0.4 && ratio < 0.6);
+  }
+
+  /** IT-FLIP-01 — clicking Flip swaps the source viewer between slots (client-originated). */
+  @Test
+  public void clickingFlipSwapsSlots() {
+    open();
+    assertTrue(hasElement("[slot='secondary'] code-viewer"));
+    assertFalse(hasElement("[slot='primary'] code-viewer"));
+
+    click("flip");
+
+    waitUntil(d -> hasElement("[slot='primary'] code-viewer"));
+    assertTrue($server.lastPositionFromClient());
+
+    click("flip");
+    waitUntil(d -> hasElement("[slot='secondary'] code-viewer"));
+  }
+
+  /** IT-ROT-01 — clicking Rotate toggles the split orientation (client-originated). */
+  @Test
+  public void clickingRotateTogglesOrientation() {
+    open();
+    assertEquals(HORIZONTAL, $server.orientation());
+    assertEquals("horizontal", orientationAttribute());
+
+    click("rotate");
+
+    assertEquals(VERTICAL, $server.orientation());
+    waitUntil(d -> "vertical".equals(orientationAttribute()));
+    assertTrue($server.lastOrientationFromClient());
+
+    click("rotate");
+    assertEquals(HORIZONTAL, $server.orientation());
+  }
+
+  /**
+   * IT-VIS-01 (optional) — at the collapsed extreme the overlay container falls below every
+   * {@code @container} threshold, so only the show button remains visible.
+   */
+  @Test
+  public void collapsedPanelHidesActionButtons() {
+    open();
+    click("hide");
+    waitUntil(d -> button("show").isDisplayed());
+
+    assertFalse(button("hide").isDisplayed());
+    assertFalse(button("flip").isDisplayed());
+    assertFalse(button("rotate").isDisplayed());
+  }
+}

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayView.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/OverlayView.java
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.it;
+
+import com.flowingcode.vaadin.addons.GithubLink;
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
+import com.flowingcode.vaadin.addons.demo.TabbedDemo;
+import com.flowingcode.vaadin.jsonmigration.InstrumentedRoute;
+import com.flowingcode.vaadin.jsonmigration.JsonMigration;
+import com.flowingcode.vaadin.jsonmigration.LegacyClientCallable;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+
+@SuppressWarnings("serial")
+@GithubLink("https://github.com/FlowingCode/CommonsDemo")
+public class OverlayView extends TabbedDemo implements OverlayCallables {
+
+  private boolean collapsed;
+  private boolean collapseFromClient;
+  private SourcePosition position;
+  private boolean positionFromClient;
+  private boolean orientationFromClient;
+
+  public OverlayView() {
+    addDemo(JsonMigration.instrumentClass(RpcOverlayDemo.class));
+    addSourceCollapseListener(ev -> {
+      collapsed = ev.isCollapsed();
+      collapseFromClient = ev.isFromClient();
+    });
+    addSourcePositionChangedListener(ev -> {
+      position = ev.getSourcePosition();
+      positionFromClient = ev.isFromClient();
+    });
+    addOrientationChangedListener(ev -> orientationFromClient = ev.isFromClient());
+  }
+
+  @Override
+  @LegacyClientCallable
+  public JsonValue $call(JsonObject invocation) {
+    return OverlayCallables.super.$call(invocation);
+  }
+
+  @Override
+  public Orientation orientation() {
+    return getOrientation();
+  }
+
+  @Override
+  public boolean sourceCollapsed() {
+    return collapsed;
+  }
+
+  @Override
+  public SourcePosition sourcePosition() {
+    return position;
+  }
+
+  @Override
+  public boolean lastCollapseFromClient() {
+    return collapseFromClient;
+  }
+
+  @Override
+  public boolean lastPositionFromClient() {
+    return positionFromClient;
+  }
+
+  @Override
+  public boolean lastOrientationFromClient() {
+    return orientationFromClient;
+  }
+
+  /** Single source-bearing demo, so the overlay controls are rendered. */
+  @DemoSource(clazz = OverlayView.class)
+  @InstrumentedRoute(value = "it/rpc-overlay", layout = OverlayView.class)
+  public static class RpcOverlayDemo extends Div {
+
+    public RpcOverlayDemo() {
+      add(new Span("RpcOverlayDemo"));
+    }
+  }
+}

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
@@ -183,6 +183,23 @@ public class TabbedDemoUIUnitTest extends UIUnit4Test {
     assertEquals(Orientation.VERTICAL, demo.getOrientation());
   }
 
+  @Test
+  public void orientationSetWithoutLayoutCarriesOverToNextDemo() {
+    // A source-less demo has no layout; setting the orientation there (as a device-driven portrait
+    // adjustment does on attach) must be remembered and applied to the next source-bearing demo.
+    TabbedDemoView demo = new TabbedDemoView();
+    Component noSource = new TabbedDemoViewNoSource();
+    demo.showRouterLayoutContent(noSource);
+
+    demo.setOrientation(Orientation.VERTICAL);
+    assertEquals(Orientation.VERTICAL, demo.getOrientation());
+
+    demo.removeRouterLayoutContent(noSource);
+    demo.showRouterLayoutContent(new TabbedDemoViewSingleSource());
+
+    assertEquals(Orientation.VERTICAL, demo.getOrientation());
+  }
+
   /** Counts elements with the given tag in the subtree rooted at {@code root} (inclusive). */
   private static long count(Element root, String tag) {
     long self = tag.equals(root.getTag()) ? 1 : 0;

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
@@ -1,0 +1,171 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
+import com.flowingcode.vaadin.addons.demo.events.OrientationChangedEvent;
+import com.flowingcode.vaadin.addons.demo.events.SourceCollapseChangedEvent;
+import com.flowingcode.vaadin.addons.demo.events.SourcePositionChangedEvent;
+import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewMultiSource;
+import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewNoSource;
+import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewSingleSource;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.testbench.unit.UIUnit4Test;
+import com.vaadin.testbench.unit.ViewPackages;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+@ViewPackages(classes = TabbedDemoView.class)
+public class TabbedDemoUIUnitTest extends UIUnit4Test {
+
+  private static final String TAG_CODE_VIEWER = "code-viewer";
+  private static final String TAG_SOURCE_CODE_VIEWER_BUTTONS = "source-code-viewer-buttons";
+
+  private static TabbedDemoView openWithSource() {
+    TabbedDemoView demo = new TabbedDemoView();
+    demo.showRouterLayoutContent(new TabbedDemoViewSingleSource());
+    return demo;
+  }
+
+  // --- the overlay is present exactly when the demo has source ----------------------
+
+  @Test
+  public void overlayPresentForSingleSource() {
+    TabbedDemoView demo = openWithSource();
+    assertEquals(1, count(demo.getElement(), TAG_SOURCE_CODE_VIEWER_BUTTONS));
+    assertEquals(1, count(demo.getElement(), TAG_CODE_VIEWER));
+  }
+
+  @Test
+  public void overlayPresentOnceForMultiSource() {
+    TabbedDemoView demo = new TabbedDemoView();
+    demo.showRouterLayoutContent(new TabbedDemoViewMultiSource());
+    assertEquals(1, count(demo.getElement(), TAG_SOURCE_CODE_VIEWER_BUTTONS));
+    assertEquals(1, count(demo.getElement(), TAG_CODE_VIEWER));
+  }
+
+  @Test
+  public void noOverlayWhenDemoHasNoSource() {
+    TabbedDemoView demo = new TabbedDemoView();
+    demo.showRouterLayoutContent(new TabbedDemoViewNoSource());
+    assertEquals(0, count(demo.getElement(), TAG_SOURCE_CODE_VIEWER_BUTTONS));
+    assertEquals(0, count(demo.getElement(), TAG_CODE_VIEWER));
+  }
+
+  // --- setSourceVisible collapses/expands and fires the event (fromClient=false) ----
+
+  @Test
+  public void setSourceVisibleFiresCollapseEvent() {
+    TabbedDemoView demo = openWithSource();
+    List<SourceCollapseChangedEvent> events = new ArrayList<>();
+    demo.addSourceCollapseListener(events::add);
+
+    demo.setSourceVisible(false);
+    assertEquals(1, events.size());
+    assertTrue(events.get(0).isCollapsed());
+    assertFalse(events.get(0).isFromClient());
+
+    demo.setSourceVisible(true);
+    assertEquals(2, events.size());
+    assertFalse(events.get(1).isCollapsed());
+    assertFalse(events.get(1).isFromClient());
+  }
+
+  // --- toggleSourcePosition toggles the position and fires the event ---------------
+
+  @Test
+  public void toggleSourcePositionFiresEventAndToggles() {
+    TabbedDemoView demo = openWithSource();
+    List<SourcePositionChangedEvent> events = new ArrayList<>();
+    demo.addSourcePositionChangedListener(events::add);
+
+    demo.toggleSourcePosition();
+    assertEquals(1, events.size());
+    // Single source defaults to SECONDARY, so the first toggle yields PRIMARY.
+    assertEquals(SourcePosition.PRIMARY, events.get(0).getSourcePosition());
+    assertFalse(events.get(0).isFromClient());
+
+    demo.toggleSourcePosition();
+    assertEquals(2, events.size());
+    assertEquals(SourcePosition.SECONDARY, events.get(1).getSourcePosition());
+    assertNotEquals(events.get(0).getSourcePosition(), events.get(1).getSourcePosition());
+  }
+
+  // --- setOrientation changes state and fires the event; same value is a no-op ------
+
+  @Test
+  public void setOrientationChangesStateAndFiresEvent() {
+    TabbedDemoView demo = openWithSource();
+    assertEquals(Orientation.HORIZONTAL, demo.getOrientation());
+    List<OrientationChangedEvent> events = new ArrayList<>();
+    demo.addOrientationChangedListener(events::add);
+
+    demo.setOrientation(Orientation.VERTICAL);
+
+    assertEquals(Orientation.VERTICAL, demo.getOrientation());
+    assertEquals(1, events.size());
+    assertEquals(Orientation.VERTICAL, events.get(0).getOrientation());
+    assertFalse(events.get(0).isFromClient());
+  }
+
+  @Test
+  public void settingCurrentOrientationIsANoOp() {
+    TabbedDemoView demo = openWithSource();
+    List<OrientationChangedEvent> events = new ArrayList<>();
+    demo.addOrientationChangedListener(events::add);
+
+    demo.setOrientation(Orientation.HORIZONTAL); // already horizontal
+
+    assertEquals(Orientation.HORIZONTAL, demo.getOrientation());
+    assertTrue(events.isEmpty());
+  }
+
+  // --- orientation carries over to the next demo ------------------------------------
+
+  @Test
+  public void orientationPersistsAcrossContentChange() {
+    TabbedDemoView demo = new TabbedDemoView();
+    Component first = new TabbedDemoViewSingleSource();
+    demo.showRouterLayoutContent(first);
+    demo.setOrientation(Orientation.VERTICAL);
+    assertEquals(Orientation.VERTICAL, demo.getOrientation());
+
+    demo.removeRouterLayoutContent(first);
+    demo.showRouterLayoutContent(new TabbedDemoViewMultiSource());
+
+    assertEquals(Orientation.VERTICAL, demo.getOrientation());
+  }
+
+  /** Counts elements with the given tag in the subtree rooted at {@code root} (inclusive). */
+  private static long count(Element root, String tag) {
+    long self = tag.equals(root.getTag()) ? 1 : 0;
+    return self + root.getChildren()
+        .filter(e -> !e.isTextNode())
+        .mapToLong(child -> count(child, tag)).sum();
+  }
+
+}

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoUIUnitTest.java
@@ -29,6 +29,7 @@ import com.flowingcode.vaadin.addons.demo.events.SourceCollapseChangedEvent;
 import com.flowingcode.vaadin.addons.demo.events.SourcePositionChangedEvent;
 import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewMultiSource;
 import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewNoSource;
+import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewPrimarySource;
 import com.flowingcode.vaadin.addons.demo.it.TabbedDemoView.TabbedDemoViewSingleSource;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
@@ -113,6 +114,28 @@ public class TabbedDemoUIUnitTest extends UIUnit4Test {
     assertEquals(2, events.size());
     assertEquals(SourcePosition.SECONDARY, events.get(1).getSourcePosition());
     assertNotEquals(events.get(0).getSourcePosition(), events.get(1).getSourcePosition());
+  }
+
+  // --- a DEFAULT position inherits the position carried over from the previous demo -
+
+  @Test
+  public void defaultPositionInheritsFromPreviousDemo() {
+    TabbedDemoView demo = new TabbedDemoView();
+    Component first = new TabbedDemoViewPrimarySource();
+    demo.showRouterLayoutContent(first);
+
+    // TabbedDemoViewSingleSource has no explicit position (DEFAULT), so it should adopt
+    // the PRIMARY position carried over from the previous demo.
+    demo.removeRouterLayoutContent(first);
+    demo.showRouterLayoutContent(new TabbedDemoViewSingleSource());
+
+    List<SourcePositionChangedEvent> events = new ArrayList<>();
+    demo.addSourcePositionChangedListener(events::add);
+
+    demo.toggleSourcePosition();
+    assertEquals(1, events.size());
+    // Inherited PRIMARY, so the first toggle yields SECONDARY.
+    assertEquals(SourcePosition.SECONDARY, events.get(0).getSourcePosition());
   }
 
   // --- setOrientation changes state and fires the event; same value is a no-op ------

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoView.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/TabbedDemoView.java
@@ -22,6 +22,7 @@ package com.flowingcode.vaadin.addons.demo.it;
 import com.flowingcode.vaadin.addons.GithubLink;
 import com.flowingcode.vaadin.addons.demo.AdHocDemo;
 import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
 import com.flowingcode.vaadin.addons.demo.TabbedDemo;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
@@ -34,6 +35,7 @@ public class TabbedDemoView extends TabbedDemo {
   public TabbedDemoView() {
     addDemo(TabbedDemoViewNoSource.class);
     addDemo(TabbedDemoViewSingleSource.class);
+    addDemo(TabbedDemoViewPrimarySource.class);
     addDemo(TabbedDemoViewMultiSource.class);
     addDemo(TabbedDemoViewConditionalTrue.class);
     addDemo(TabbedDemoViewConditionalFalse.class);
@@ -51,6 +53,10 @@ public class TabbedDemoView extends TabbedDemo {
   @DemoSource(clazz = TabbedDemoView.class)
   @Route(value = "it/tabbed-demo-single-source", layout = TabbedDemoView.class)
   public static class TabbedDemoViewSingleSource extends AbstractDemoView { }
+
+  @DemoSource(clazz = TabbedDemoView.class, sourcePosition = SourcePosition.PRIMARY)
+  @Route(value = "it/tabbed-demo-primary-source", layout = TabbedDemoView.class)
+  public static class TabbedDemoViewPrimarySource extends AbstractDemoView { }
 
   @DemoSource(clazz = TabbedDemoView.class)
   @DemoSource(clazz = AdHocDemo.class)

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/ViewInitializerImpl.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/it/ViewInitializerImpl.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.it;
+import com.flowingcode.vaadin.jsonmigration.InstrumentationViewInitializer;
+import com.vaadin.flow.server.ServiceInitEvent;
+
+/**
+ * Service initializer for instrumented test views.
+ *
+ * @author Javier Godoy / Flowing Code
+ */
+@SuppressWarnings("serial")
+public class ViewInitializerImpl extends InstrumentationViewInitializer {
+
+  @Override
+  public void serviceInit(ServiceInitEvent event) {
+    registerInstrumentedRoute(OverlayView.RpcOverlayDemo.class);
+  }
+
+}

--- a/base/src/test/java/com/flowingcode/vaadin/addons/demo/test/SplitLayoutDemoTest.java
+++ b/base/src/test/java/com/flowingcode/vaadin/addons/demo/test/SplitLayoutDemoTest.java
@@ -1,0 +1,179 @@
+/*-
+ * #%L
+ * Commons Demo
+ * %%
+ * Copyright (C) 2020 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.demo.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import com.flowingcode.vaadin.addons.demo.SourceCodeTab;
+import com.flowingcode.vaadin.addons.demo.SourcePosition;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.experimental.ExtensionMethod;
+import org.junit.Test;
+
+@ExtensionMethod(value = Reflect.class, suppressBaseMethods = true)
+public class SplitLayoutDemoTest {
+
+  private Div demo;
+
+  private Component build(SourcePosition position) {
+    demo = new Div();
+    demo.setId("content");
+    return Reflect.newSplitLayoutDemo(demo,
+        List.of(new SourceCodeTab("src/test/java/Demo.java", position)));
+  }
+
+  // --- collapse resolves to the correct splitter position -----------------------
+
+  @Test
+  public void collapseWithSecondarySourceMovesSplitterToFullPrimary() {
+    Component layout = build(SourcePosition.SECONDARY);
+
+    layout.setSourceCollapsed(false);
+    assertEquals(50.0, splitterPosition(layout), 0.0);
+
+    layout.setSourceCollapsed(true);
+    assertEquals(100.0, splitterPosition(layout), 0.0);
+
+    layout.setSourceCollapsed(false);
+    assertEquals(50.0, splitterPosition(layout), 0.0);
+  }
+
+  @Test
+  public void collapseWithPrimarySourceMovesSplitterToFullSecondary() {
+    Component layout = build(SourcePosition.PRIMARY);
+
+    layout.setSourceCollapsed(true);
+    assertEquals(0.0, splitterPosition(layout), 0.0);
+
+    layout.setSourceCollapsed(false);
+    assertEquals(50.0, splitterPosition(layout), 0.0);
+  }
+
+  // --- source position swaps slot occupants and toggles cleanly -----------------
+
+  @Test
+  public void sourcePositionSwapsSlotsAndToggles() {
+    Component layout = build(SourcePosition.SECONDARY);
+
+    // Default SECONDARY: demo in primary, source viewer in secondary.
+    assertSame(demo, layout.getContent().getPrimaryComponent());
+    assertNotSame(demo, layout.getContent().getSecondaryComponent());
+    Component code = layout.getContent().getSecondaryComponent();
+
+    layout.setSourcePosition(SourcePosition.PRIMARY);
+    assertSame(code, layout.getContent().getPrimaryComponent());
+    assertSame(demo, layout.getContent().getSecondaryComponent());
+    assertEquals(SourcePosition.PRIMARY, layout.getSourcePosition());
+
+    layout.setSourcePosition(SourcePosition.SECONDARY);
+    assertSame(demo, layout.getContent().getPrimaryComponent());
+    assertSame(code, layout.getContent().getSecondaryComponent());
+    assertEquals(SourcePosition.SECONDARY, layout.getSourcePosition());
+  }
+
+  // --- orientation set/get round-trips ------------------------------------------
+
+  @Test
+  public void orientationRoundTrips() {
+    Component layout = build(SourcePosition.SECONDARY);
+    assertEquals(Orientation.HORIZONTAL, layout.getOrientation());
+
+    layout.setOrientation(Orientation.VERTICAL);
+    assertEquals(Orientation.VERTICAL, layout.getOrientation());
+
+    layout.setOrientation(Orientation.HORIZONTAL);
+    assertEquals(Orientation.HORIZONTAL, layout.getOrientation());
+  }
+
+  private static double splitterPosition(Component layout) {
+    Double position = layout.getContent().getSplitterPosition();
+    assertNotNull("splitter position was never set", position);
+    return position;
+  }
+
+}
+
+
+/**
+ * Reflection accessors for the package-private {@code SplitLayoutDemo} and the protected
+ * {@code Composite.getContent()}, one static method per real method. Surfaced as Lombok
+ * {@code @ExtensionMethod}s so the test can drive the layout with real-API-looking call sites while
+ * the actual dispatch goes through reflection.
+ */
+final class Reflect {
+
+  private Reflect() {}
+
+  @SneakyThrows
+  static Component newSplitLayoutDemo(Component demo, List<SourceCodeTab> tabs) {
+    Class<?> type = Class.forName("com.flowingcode.vaadin.addons.demo.SplitLayoutDemo");
+    Constructor<?> constructor = type.getDeclaredConstructor(Component.class, List.class);
+    constructor.setAccessible(true);
+    return (Component) constructor.newInstance(demo, tabs);
+  }
+
+  public static void setSourceCollapsed(Component layout, boolean collapsed) {
+    call(layout, "setSourceCollapsed", new Class<?>[] {boolean.class}, collapsed);
+  }
+
+  public static void setSourcePosition(Component layout, SourcePosition position) {
+    call(layout, "setSourcePosition", new Class<?>[] {SourcePosition.class}, position);
+  }
+
+  public static void setOrientation(Component layout, Orientation orientation) {
+    call(layout, "setOrientation", new Class<?>[] {Orientation.class}, orientation);
+  }
+
+  public static Orientation getOrientation(Component layout) {
+    return (Orientation) call(layout, "getOrientation", new Class<?>[0]);
+  }
+
+  public static SourcePosition getSourcePosition(Component layout) {
+    return (SourcePosition) call(layout, "getSourcePosition", new Class<?>[0]);
+  }
+
+  public static SplitLayout getContent(Component layout) {
+    return (SplitLayout) call(layout, "getContent", new Class<?>[0]);
+  }
+
+  /** Locates {@code name(paramTypes)} on {@code target} or a supertype and invokes it. */
+  @SneakyThrows
+  private static Object call(Object target, String name, Class<?>[] paramTypes, Object... args) {
+    for (Class<?> c = target.getClass(); c != null; c = c.getSuperclass()) {
+      try {
+        Method method = c.getDeclaredMethod(name, paramTypes);
+        method.setAccessible(true);
+        return method.invoke(target, args);
+      } catch (NoSuchMethodException declaredInSupertype) {
+        // keep walking up the hierarchy
+      }
+    }
+    throw new NoSuchMethodException(target.getClass().getName() + "#" + name);
+  }
+}

--- a/base/src/test/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/base/src/test/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.flowingcode.vaadin.addons.demo.it.ViewInitializerImpl

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.flowingcode.vaadin.addons.demo</groupId>
   <artifactId>commons-demo-aggregator</artifactId>
-  <version>5.3.2-SNAPSHOT</version>
+  <version>5.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Commons Demo Aggregator</name>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.flowingcode.vaadin.addons.demo</groupId>
   <artifactId>commons-demo-processor</artifactId>
-  <version>5.3.2-SNAPSHOT</version>
+  <version>5.4.0-SNAPSHOT</version>
 
   <name>Commons Demo Processor</name>
   <description>Annotation processor for Commons Demo: copies @DemoSource-referenced files into the class output</description>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-code viewer overlay controls (show/hide, flip, rotate) across the relevant demos.
  * Introduced the `commons-demo` iconset and new demo icon factory.
  * Added public events/listeners for source collapse, source position, and split orientation.
  * Added `SourcePosition.DEFAULT` with improved inheritance/carry-over behavior.
* **Bug Fixes**
  * Improved overlay/viewer synchronization during attach, scrolling, and layout/content swapping.
* **Tests**
  * Added/expanded integration and UI tests covering overlay controls, splitter behavior, and event firing.
* **Chores**
  * Updated snapshot version to `5.4.0-SNAPSHOT` and refreshed test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->